### PR TITLE
[Feat]  날짜별 데이터 저장_시도 횟수 저장

### DIFF
--- a/Sources/DashBoardScene/ViewControllers/DayViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DayViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import SnapKit
 
 final class DayViewController: UIViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
@@ -27,6 +26,7 @@ final class DayViewController: UIViewController {
         $0.textAlignment = .center
         $0.textColor = .black
     }
+    
     private func setupDateLabel() {
         view.addSubview(dateLabel)
         dateLabel.snp.makeConstraints{ make in
@@ -38,9 +38,11 @@ final class DayViewController: UIViewController {
     private let previousButton = UIButton().then {
         $0.setImage(UIImage(systemName: "arrowtriangle.backward")?.withTintColor(.black, renderingMode: .alwaysOriginal), for: .normal)
     }
+    
     private let nextButton = UIButton().then {
         $0.setImage(UIImage(systemName: "arrowtriangle.right")?.withTintColor(.black, renderingMode: .alwaysOriginal), for: .normal)
     }
+    
     private func setupArrowButtons() {
         view.addSubview(previousButton)
         view.addSubview(nextButton)
@@ -53,6 +55,7 @@ final class DayViewController: UIViewController {
             make.leading.equalTo(dateLabel.snp.trailing).offset(10)
         }
     }
+    
     private func getLayout() -> UICollectionViewCompositionalLayout {
         UICollectionViewCompositionalLayout { (section, _) -> NSCollectionLayoutSection? in
             

--- a/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
@@ -40,14 +40,14 @@ final class MonthViewController: UIViewController {
         setupPieView()
         ChangePieCenterText()
         setPieData(pieChartView: donutPieChartView , pieChartDataEntries:
-                            entryData(values: priceData))
+                    entryData(values: priceData))
         
     }
     
     private func ChangePieCenterText() {
         
         let attributeString = NSAttributedString(string: "총합", attributes: [ NSAttributedString.Key.font: UIFont.systemFont(ofSize: 25, weight: .bold)
-            ])
+                                                                           ])
         
         donutPieChartView.centerAttributedText = attributeString
     }
@@ -64,9 +64,9 @@ final class MonthViewController: UIViewController {
             make.width.height.equalTo(view.bounds.width * 0.65)
         }
     }
-
+    
     func entryData(values: [Double]) -> [ChartDataEntry] {
-
+        
         var pieDataEntries: [ChartDataEntry] = []
         for i in 0 ..< values.count {
             let pieDataEntry = ChartDataEntry(x: Double(i), y: values[i])

--- a/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
@@ -39,15 +39,25 @@ final class MonthViewController: UIViewController {
         view.backgroundColor = .white
         setupPieView()
         ChangePieCenterText()
-        setPieData(pieChartView: donutPieChartView , pieChartDataEntries:
-                    entryData(values: priceData))
-        
+        setPieData(
+            pieChartView: donutPieChartView ,
+            pieChartDataEntries:
+                entryData(
+                    values: priceData
+                )
+        )
     }
     
     private func ChangePieCenterText() {
         
-        let attributeString = NSAttributedString(string: "총합", attributes: [ NSAttributedString.Key.font: UIFont.systemFont(ofSize: 25, weight: .bold)
-                                                                           ])
+        let attributeString = NSAttributedString(
+            string: "총합",
+            attributes: [ NSAttributedString.Key.font: UIFont.systemFont(
+                ofSize: 25,
+                weight: .bold
+            )
+                        ]
+        )
         
         donutPieChartView.centerAttributedText = attributeString
     }
@@ -66,7 +76,6 @@ final class MonthViewController: UIViewController {
     }
     
     func entryData(values: [Double]) -> [ChartDataEntry] {
-        
         var pieDataEntries: [ChartDataEntry] = []
         for i in 0 ..< values.count {
             let pieDataEntry = ChartDataEntry(x: Double(i), y: values[i])
@@ -76,7 +85,10 @@ final class MonthViewController: UIViewController {
     }
     
     func setPieData(pieChartView: PieChartView, pieChartDataEntries: [ChartDataEntry]) {
-        let pieChartdataSet = PieChartDataSet(entries: pieChartDataEntries, label: "")
+        let pieChartdataSet = PieChartDataSet(
+            entries: pieChartDataEntries,
+            label: ""
+        )
         pieChartdataSet.colors = [UIColor.black]
         pieChartdataSet.drawValuesEnabled = false
         

--- a/Sources/DashBoardScene/Views/CompositionalCell.swift
+++ b/Sources/DashBoardScene/Views/CompositionalCell.swift
@@ -55,17 +55,24 @@ final class FirstCell: UICollectionViewCell {
     }
     
     private func setupUI() {
-        let statistics = TotalPomodoro(sessions: PomodoroData.dummyData)
-        setupLabel(participateLabel, text: "참여일 \(statistics.totalDate)일", topOffset: 70, centerXOffset: -100)
-        setupLabel(countLabel, text: "횟수 \(statistics.totalSessions)번", topOffset: 70, centerXOffset: 50)
-        setupLabel(achieveLabel, text: "달성 \(statistics.totalSuccesses)번", topOffset: 160, centerXOffset: -100)
-        setupLabel(failLabel, text: "실패 \(statistics.totalFailures)번", topOffset: 160, centerXOffset: 50)
+        let filteredData = getPomodoroData(forDate: Date())
+        let participateCount = filteredData.count
+        let totalSuccesses = filteredData.filter { $0.success }.count
+        let totalFailures = filteredData.filter { !$0.success }.count
         
+        setupLabel(participateLabel, text: "참여일 \(participateCount)일", topOffset: 70, centerXOffset: -100)
+        setupLabel(countLabel, text: "횟수 \(filteredData.count)번", topOffset: 70, centerXOffset: 50)
+        setupLabel(achieveLabel, text: "달성 \(totalSuccesses)번", topOffset: 160, centerXOffset: -100)
+        setupLabel(failLabel, text: "실패 \(totalFailures)번", topOffset: 160, centerXOffset: 50)
         setupDivider(horizonDivider, isHorizontal: true, length: 325, offset: 130)
         setupDivider(verticalDivider, isHorizontal: false, length: 155, offset: 50)
         
         self.layer.cornerRadius = 20
         self.backgroundColor = .black
+    }
+    
+    func getPomodoroData(forDate date: Date) -> [PomodoroData] {
+        return PomodoroData.dummyData.filter { $0.participateDate <= date }
     }
 }
 

--- a/Sources/DashBoardScene/Views/CompositionalCell.swift
+++ b/Sources/DashBoardScene/Views/CompositionalCell.swift
@@ -57,13 +57,13 @@ final class FirstCell: UICollectionViewCell {
     private func setupUI() {
         let filteredData = getPomodoroData(forDate: Date())
         let participateCount = filteredData.count
-        let totalSuccesses = filteredData.filter { $0.success }.count
-        let totalFailures = filteredData.filter { !$0.success }.count
+        let totalSuccessCount = filteredData.filter { $0.success }.count
+        let totalFailureCount = filteredData.filter { !$0.success }.count
         
         setupLabel(participateLabel, text: "참여일 \(participateCount)일", topOffset: 70, centerXOffset: -100)
         setupLabel(countLabel, text: "횟수 \(filteredData.count)번", topOffset: 70, centerXOffset: 50)
-        setupLabel(achieveLabel, text: "달성 \(totalSuccesses)번", topOffset: 160, centerXOffset: -100)
-        setupLabel(failLabel, text: "실패 \(totalFailures)번", topOffset: 160, centerXOffset: 50)
+        setupLabel(achieveLabel, text: "달성 \(totalSuccessCount)번", topOffset: 160, centerXOffset: -100)
+        setupLabel(failLabel, text: "실패 \(totalFailureCount)번", topOffset: 160, centerXOffset: 50)
         setupDivider(horizonDivider, isHorizontal: true, length: 325, offset: 130)
         setupDivider(verticalDivider, isHorizontal: false, length: 155, offset: 50)
         
@@ -72,7 +72,7 @@ final class FirstCell: UICollectionViewCell {
     }
     
     func getPomodoroData(forDate date: Date) -> [PomodoroData] {
-        return PomodoroData.dummyData.filter { $0.participateDate <= date }
+        PomodoroData.dummyData.filter { $0.participateDate <= date }
     }
 }
 

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -13,20 +13,24 @@ struct PomodoroData {
     var breakTime: Int
     var focusTime: Int
     var tagId: String
-    var participateDate: Int
+    var participateDate: Date
     var success: Bool
     
     static var dummyData: [PomodoroData] {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let defaultDate = Date()
+        
         return [
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: 2, success: true),
-            PomodoroData(breakTime: 5, focusTime: 30, tagId: "운동", participateDate: 2, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: 2, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: 2, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: 2, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: 2, success: true),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: 2, success: true),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: 2, success: true),
-            PomodoroData(breakTime: 5, focusTime: 20, tagId: "스터디", participateDate: 2, success: true),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-01") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 30, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-08") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-10") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-09") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 20, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-01") ?? defaultDate, success: true),
         ]
     }
 }

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -40,7 +40,7 @@ struct TotalPomodoro {
     var totalSuccesses: Int
     var totalFailures: Int
     var totalDate: Int
-
+    
     init(sessions: [PomodoroData]) {
         self.totalSessions = sessions.count
         self.totalSuccesses = sessions.filter { $0.success }.count


### PR DESCRIPTION
[feat] 시간 설정 기능
## 🗣 설명

<img width="298" alt="스크린샷 2024-01-08 오후 6 13 38" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/3a03246b-7460-4b5e-89b2-0aee89d35c48">

오늘 날짜를 기준으로 데이터를 불러옴


## 📋 체크리스트
> 구현해야하는 이슈 체크리스트
- [x] 오늘 날짜를 기준으로 데이터 필터링
- [x] ~ 오늘 날짜까지의 데이터 표시 (총 시도 횟수, 성공 횟수, 실패 횟수)