### PR TITLE
[Feat] 날짜별 데이터 저장

### DIFF
--- a/Sources/DashBoardScene/ViewControllers/DayViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DayViewController.swift
@@ -9,13 +9,14 @@
 import UIKit
 import SnapKit
 
+protocol DayViewControllerDelegate {
+    func sendSelectedDate(data: Date)
+}
+
 final class DayViewController: UIViewController {
-    
-    var selectedDate = Date() {
-        didSet{
-            updateSelectedDateFormat()
-        }
-    }
+    private var delegate : DayViewControllerDelegate?
+    private let firstCell = FirstCell()
+    private var selectedDate = Date()
     private let calendar = Calendar.current
     private let dateFormatter = DateFormatter().then {
         $0.dateStyle = .long
@@ -151,20 +152,25 @@ final class DayViewController: UIViewController {
         guard let nextDay = calendar.date(byAdding: .day, value: 1, to: selectedDate) else {
             return
         }
-        
         if nextDay <= currentDate {
             selectedDate = nextDay
             updateSelectedDateFormat()
+            delegate?.sendSelectedDate(data: selectedDate)
         } else{
             return
         }
+        firstCell.sendSelectedDate(data: selectedDate)
+        self.collectionView.reloadData()
     }
     
     @objc private func goToPreviousDay() {
         if let previousDay = calendar.date(byAdding: .day, value: -1, to: selectedDate) {
             selectedDate = previousDay
             updateSelectedDateFormat()
+            delegate?.sendSelectedDate(data: selectedDate)
         }
+        firstCell.sendSelectedDate(data: selectedDate)
+        self.collectionView.reloadData()
     }
 }
 //MARK: - UICollectionViewDataSource
@@ -186,6 +192,8 @@ extension DayViewController: UICollectionViewDataSource {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "FirstCell", for: indexPath) as? FirstCell else {
                 return UICollectionViewCell()
             }
+            cell.updateUI(for: selectedDate)
+            
             return cell
         case .second(_):
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SecondCell", for: indexPath) as? SecondCell else {

--- a/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/MonthViewController.swift
@@ -12,15 +12,15 @@ import SnapKit
 
 final class MonthViewController: UIViewController {
     
-    var dayData: [String] = [" "]
-    var priceData: [Double] = [10]
+    var dayData: [String] = []
+    var totalData: [Double] = [10]
     
     private let pieBackgroundView  = UIView().then { view in
         view.layer.cornerRadius = 20
         view.backgroundColor = .systemGray3
     }
     
-    private let donutPieChartView = PieChartView().then{ chart in
+    private let donutPieChartView = PieChartView().then { chart in
         chart.noDataText = "출력 데이터가 없습니다."
         chart.centerText = "총합"
         chart.noDataFont = .systemFont(ofSize: 20)
@@ -38,26 +38,19 @@ final class MonthViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         setupPieView()
-        ChangePieCenterText()
-        setPieData(
-            pieChartView: donutPieChartView ,
-            pieChartDataEntries:
-                entryData(
-                    values: priceData
-                )
-        )
+        changePieCenterTextFont()
+        let pieChartDataEntries = totalData.enumerated().map { (index, value) in
+            return ChartDataEntry(x: Double(index), y: value)
+        }
+        setPieData(pieChartView: donutPieChartView , pieChartDataEntries:
+                    pieChartDataEntries)
+        
     }
     
-    private func ChangePieCenterText() {
+    private func changePieCenterTextFont() {
         
-        let attributeString = NSAttributedString(
-            string: "총합",
-            attributes: [ NSAttributedString.Key.font: UIFont.systemFont(
-                ofSize: 25,
-                weight: .bold
-            )
-                        ]
-        )
+        let attributeString = NSAttributedString(string: "총합", attributes: [ NSAttributedString.Key.font: UIFont.systemFont(ofSize: 25, weight: .bold)
+                                                                           ])
         
         donutPieChartView.centerAttributedText = attributeString
     }
@@ -76,24 +69,19 @@ final class MonthViewController: UIViewController {
     }
     
     func entryData(values: [Double]) -> [ChartDataEntry] {
-        var pieDataEntries: [ChartDataEntry] = []
-        for i in 0 ..< values.count {
-            let pieDataEntry = ChartDataEntry(x: Double(i), y: values[i])
-            pieDataEntries.append(pieDataEntry)
+        
+        let pieDataEntries = values.enumerated().map { (index, value) in
+            return ChartDataEntry(x: Double(index), y: value)
         }
         return pieDataEntries
     }
     
     func setPieData(pieChartView: PieChartView, pieChartDataEntries: [ChartDataEntry]) {
-        let pieChartdataSet = PieChartDataSet(
-            entries: pieChartDataEntries,
-            label: ""
-        )
+        let pieChartdataSet = PieChartDataSet(entries: pieChartDataEntries, label: "")
         pieChartdataSet.colors = [UIColor.black]
         pieChartdataSet.drawValuesEnabled = false
         
         let pieChartData = PieChartData(dataSet: pieChartdataSet)
         pieChartView.data = pieChartData
     }
-    
 }

--- a/Sources/DashBoardScene/Views/CompositionalCell.swift
+++ b/Sources/DashBoardScene/Views/CompositionalCell.swift
@@ -11,13 +11,26 @@ import SnapKit
 import Then
 import DGCharts
 
-final class FirstCell: UICollectionViewCell {
+final class FirstCell: UICollectionViewCell, DayViewControllerDelegate {
+    
     let horizonDivider = UIView()
     let verticalDivider = UIView()
     let participateLabel = UILabel()
     let countLabel = UILabel()
     let achieveLabel = UILabel()
     let failLabel = UILabel()
+    var getSelectedDate: Date = Date()
+    
+    func updateUI(for date: Date) {
+        let filteredData = getPomodoroData(forDate: date)
+        let participateCount = filteredData.count
+        let totalSuccessCount = filteredData.filter { $0.success }.count
+        let totalFailureCount = filteredData.filter { !$0.success }.count
+        participateLabel.text = "참여일  \(participateCount)"
+        countLabel.text = "횟수 \(filteredData.count)"
+        achieveLabel.text = "달성 \(totalSuccessCount)"
+        failLabel.text = "실패 \(totalFailureCount)"
+    }
     
     private func setupLabel(_ label: UILabel, text: String, topOffset: CGFloat, centerXOffset: CGFloat) {
         label.textColor = .white
@@ -55,12 +68,12 @@ final class FirstCell: UICollectionViewCell {
     }
     
     private func setupUI() {
-        let filteredData = getPomodoroData(forDate: Date())
+        let filteredData = getPomodoroData(forDate: getSelectedDate)
         let participateCount = filteredData.count
         let totalSuccessCount = filteredData.filter { $0.success }.count
         let totalFailureCount = filteredData.filter { !$0.success }.count
         
-        setupLabel(participateLabel, text: "참여일 \(participateCount)일", topOffset: 70, centerXOffset: -100)
+        setupLabel(participateLabel, text: "참여일 \(participateCount)", topOffset: 70, centerXOffset: -100)
         setupLabel(countLabel, text: "횟수 \(filteredData.count)번", topOffset: 70, centerXOffset: 50)
         setupLabel(achieveLabel, text: "달성 \(totalSuccessCount)번", topOffset: 160, centerXOffset: -100)
         setupLabel(failLabel, text: "실패 \(totalFailureCount)번", topOffset: 160, centerXOffset: 50)
@@ -69,6 +82,10 @@ final class FirstCell: UICollectionViewCell {
         
         self.layer.cornerRadius = 20
         self.backgroundColor = .black
+    }
+    
+    func sendSelectedDate(data: Date) {
+        getSelectedDate = data
     }
     
     func getPomodoroData(forDate date: Date) -> [PomodoroData] {

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -26,7 +26,7 @@ struct PomodoroData {
             PomodoroData(breakTime: 5, focusTime: 30, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: false),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-08") ?? defaultDate, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-10") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-12") ?? defaultDate, success: false),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-09") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -30,7 +30,7 @@ struct PomodoroData {
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-09") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),
-            PomodoroData(breakTime: 5, focusTime: 20, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-01") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 20, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-17") ?? defaultDate, success: true),
         ]
     }
 }

--- a/Sources/MainScene/ViewControllers/MainPageViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainPageViewController.swift
@@ -10,53 +10,51 @@ import UIKit
 import SnapKit
 
 final class MainPageViewController: UIViewController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         if let firstVC = dataViewControllers.first(where: { $0 is MainViewController }) {
-                   pageViewController.setViewControllers([firstVC], direction: .forward, animated: true, completion: nil)
-       }
+            pageViewController.setViewControllers([firstVC], direction: .forward, animated: true, completion: nil)
+        }
         setupDelegate()
         setupPageViewController()
     }
     private lazy var dataViewControllers: [UIViewController] = {
         return [SettingViewController(), MainViewController(), DashBoardViewController()]
     }()
-
+    
     private lazy var pageViewController: UIPageViewController = {
-       let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
-       return vc
+        let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        return vc
     }()
     
     private func setupPageViewController() {
-       addChild(pageViewController)
-       view.addSubview(pageViewController.view)
-      
-       pageViewController.view.snp.makeConstraints { make in
-           make.edges.equalToSuperview()
-       }
-       pageViewController.didMove(toParent: self)
+        addChild(pageViewController)
+        view.addSubview(pageViewController.view)
+        
+        pageViewController.view.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        pageViewController.didMove(toParent: self)
     }
     private func setupDelegate() {
-       pageViewController.dataSource = self
-       pageViewController.delegate = self
+        pageViewController.dataSource = self
+        pageViewController.delegate = self
     }
 }
 
 extension MainPageViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
-
+    
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        
         guard let index = dataViewControllers.firstIndex(of: viewController) else { return nil }
-        
         let previousIndex = index - 1
         if previousIndex < 0 {
             return nil
         }
         return dataViewControllers[previousIndex]
     }
-
+    
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let index = dataViewControllers.firstIndex(of: viewController) else { return nil }
         let nextIndex = index + 1

--- a/Sources/MainScene/ViewControllers/MainPageViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainPageViewController.swift
@@ -47,7 +47,9 @@ final class MainPageViewController: UIViewController {
 extension MainPageViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        
         guard let index = dataViewControllers.firstIndex(of: viewController) else { return nil }
+        
         let previousIndex = index - 1
         if previousIndex < 0 {
             return nil

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -1,0 +1,9 @@
+//
+//  File.swift
+//  Pomodoro
+//
+//  Created by 김하람 on 1/11/24.
+//  Copyright © 2024 io.hgu. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
# ✅ 관련 issue
close #54 
close #57 
close #58 
close #75 

# 🗣 설명

<img width="234" alt="스크린샷 2024-01-18 오후 3 56 36" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/7ce0ace7-b5d0-42ab-a6f1-ad1e17a00ddb">
<img width="234" alt="스크린샷 2024-01-18 오후 3 56 44" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/46668cee-3876-4fff-ae36-20acce4d5ea2">

선택한 날짜까지를 기준으로 데이터 가져와 표시하기

<br>

## **📋 체크리스트**
구현해야하는 이슈 체크리스트

- [x] 선택한 날짜 기준 사용량 표시_참여일 (#54)
- [x] 날짜별 데이터 저장_실패, 성공 횟수 저장 (#57)
- [x] 날짜별 데이터 저장_시도 횟수 저장 (#58 )
- [x] 날짜별 데이터 저장_캘린더 코드 연결 후 데이터 저장 (#75)


## 기타

코드가 모두 연결되다보니 PR에 한번에 많은 내용이 담겨있게 되네요..
이슈와 pr을 적절하게 나누도록 더 노력하겠습니다..!