### PR TITLE
[Fix] 선택한 날짜 기준 사용량 표시 _ 로직 수정

### DIFF
--- a/Sources/DashBoardScene/Views/CompositionalCell.swift
+++ b/Sources/DashBoardScene/Views/CompositionalCell.swift
@@ -23,7 +23,8 @@ final class FirstCell: UICollectionViewCell, DayViewControllerDelegate {
     
     func updateUI(for date: Date) {
         let filteredData = getPomodoroData(forDate: date)
-        let participateCount = filteredData.count
+        let totalParticipate = getTotalParticipateDate(forDate: date)
+        let participateCount = totalParticipate.count
         let totalSuccessCount = filteredData.filter { $0.success }.count
         let totalFailureCount = filteredData.filter { !$0.success }.count
         participateLabel.text = "참여일  \(participateCount)"
@@ -70,7 +71,8 @@ final class FirstCell: UICollectionViewCell, DayViewControllerDelegate {
     
     private func setupUI() {
         let filteredData = getPomodoroData(forDate: getSelectedDate)
-        let participateCount = filteredData.count
+        let totalParticipate = getTotalParticipateDate(forDate: getSelectedDate)
+        let participateCount = totalParticipate.count
         let totalSuccessCount = filteredData.filter { $0.success }.count
         let totalFailureCount = filteredData.filter { !$0.success }.count
         
@@ -89,8 +91,14 @@ final class FirstCell: UICollectionViewCell, DayViewControllerDelegate {
         getSelectedDate = data
     }
     
-    func getPomodoroData(forDate date: Date) -> [PomodoroData] {
+    func getTotalParticipateDate(forDate date: Date) -> [PomodoroData] {
         PomodoroData.dummyData.filter { $0.participateDate <= date }
+    }
+    func getPomodoroData(forDate date: Date) -> [PomodoroData] {
+        let calendar = Calendar.current
+        return PomodoroData.dummyData.filter {
+            calendar.isDate($0.participateDate, inSameDayAs: date)
+        }
     }
 }
 

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -48,18 +48,3 @@ struct TotalPomodoro {
         self.totalDate = 1
     }
 }
-
-// FIXME: - 임시로 사용하는 MockData입니다.
-struct TempTag {
-    var uid: String
-    var tagName: String
-    var tagDescription: String
-
-    static var dummyData: [TempTag] {
-        return [
-            TempTag(uid: "1", tagName: "공부", tagDescription: "이산수학 공부"),
-            TempTag(uid: "2", tagName: "운동", tagDescription: "필라테스"),
-            TempTag(uid: "3", tagName: "스터디", tagDescription: "iOS 스터디"),
-        ]
-    }
-}


### PR DESCRIPTION
[feat] 시간 설정 기능

close #88 

## 🗣 설명

<img width="234" alt="스크린샷 2024-01-28 오후 12 29 48" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/4c010588-e7df-480a-929d-75dcd9c574a3">

<img width="234" alt="스크린샷 2024-01-28 오후 12 29 22" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/28a248be-4d02-44a2-8062-c43047b596bd">

기존 코드는 선택한 날짜를 기준으로 이전 데이터를 모두 가져오는 방식이었습니다.
하지만, 참여일을 제외한 데이터는 선택한 날짜의 데이터만 필요하였기에, 참여일과 다른 데이터들의 기준을 달리 해야 합니다. 
이를 위해 참여일을 계산하는 필터 함수를 새로 추가하였습니다.


## 📋 체크리스트
> 구현해야하는 이슈 체크리스트
- [x] 총 시도 횟수, 성공 횟수, 실패 횟수 : 선택한 날짜의 데이터
- [x] 참여일 : ~ 오늘 날짜까지의 합 표시 