### PR TITLE
[Feat] 선택한 날짜 기준 사용량 표시_총 사용량, 원 그래프 업데이트

### DIFF
--- a/Sources/DashBoardScene/ViewControllers/DayViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DayViewController.swift
@@ -16,6 +16,7 @@ protocol DayViewControllerDelegate {
 final class DayViewController: UIViewController {
     private var delegate : DayViewControllerDelegate?
     private let firstCell = FirstCell()
+    private let secondCell = SecondCell()
     private var selectedDate = Date()
     private let calendar = Calendar.current
     private let dateFormatter = DateFormatter().then {
@@ -160,6 +161,7 @@ final class DayViewController: UIViewController {
             return
         }
         firstCell.sendSelectedDate(data: selectedDate)
+        secondCell.sendSelectedDate(data: selectedDate)
         self.collectionView.reloadData()
     }
     
@@ -170,6 +172,7 @@ final class DayViewController: UIViewController {
             delegate?.sendSelectedDate(data: selectedDate)
         }
         firstCell.sendSelectedDate(data: selectedDate)
+        secondCell.sendSelectedDate(data: selectedDate)
         self.collectionView.reloadData()
     }
 }
@@ -199,6 +202,7 @@ extension DayViewController: UICollectionViewDataSource {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SecondCell", for: indexPath) as? SecondCell else {
                 return UICollectionViewCell()
             }
+            cell.updatePieChartData(for: selectedDate)
             return cell
         }
     }

--- a/Sources/DashBoardScene/Views/MockData.swift
+++ b/Sources/DashBoardScene/Views/MockData.swift
@@ -23,9 +23,9 @@ struct PomodoroData {
         
         return [
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-01") ?? defaultDate, success: true),
-            PomodoroData(breakTime: 5, focusTime: 30, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: false),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-04") ?? defaultDate, success: true),
-            PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-08") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 30, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-28") ?? defaultDate, success: false),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-28") ?? defaultDate, success: true),
+            PomodoroData(breakTime: 5, focusTime: 25, tagId: "스터디", participateDate: dateFormatter.date(from: "2024-01-08") ?? defaultDate, success: false),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "운동", participateDate: dateFormatter.date(from: "2024-01-12") ?? defaultDate, success: false),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-09") ?? defaultDate, success: true),
             PomodoroData(breakTime: 5, focusTime: 25, tagId: "공부", participateDate: dateFormatter.date(from: "2024-01-02") ?? defaultDate, success: true),


### PR DESCRIPTION
[Feat] 선택한 날짜 기준 사용량 표시_총 사용량, 원 그래프 업데이트

close #53 
close #59 

## 🗣 설명

<img width="205" alt="스크린샷 2024-01-29 오후 8 51 30" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/27b055db-2994-449a-93ef-1cd944b20a76">

<img width="205" alt="스크린샷 2024-01-29 오후 8 51 43" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/e34e212b-dfc0-42fc-95c1-25975a744e2a">



## 📋 체크리스트
> 구현해야하는 이슈 체크리스트
- [x] 각 날짜별로 뽀모도로 카테고리별 사용 시간 저장하기
- [x] 선택한 날짜까지의 총 사용량 통계 보여주기