### PR TITLE
[Feat] #120 강제 앱 종료 시 타임스탬프 적용하기

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -12,6 +12,7 @@ import UserNotifications
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     let unNotificationCenter = UNUserNotificationCenter.current()
+    let pomodoroTimeManager = PomodoroTimeManager.shared
 
     func application(
         _: UIApplication,
@@ -23,7 +24,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options: [.alert, .sound, .badge],
             completionHandler: { _, _ in }
         )
+
+        // 앱 재시작될 때
+        print("APP INITIALIZE..")
+        pomodoroTimeManager.restoreTimerInfo()
+//        pomodoroTimeManager.startTimer()
+
         return true
+    }
+
+    func applicationWillTerminate(_: UIApplication) {
+        print("TERMINATE")
+        pomodoroTimeManager.saveTimerInfo()
+    }
+
+    func applicationDidEnterBackground(_: UIApplication) {
+        print("ENTER BACKGROUND")
+        pomodoroTimeManager.saveTimerInfo()
     }
 
     func application(

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -14,10 +14,10 @@ import UIKit
 final class MainViewController: UIViewController {
     private var timer: Timer?
     private var notificationId: String?
-    private var currentTime = 0
-    private var maxTime = 0
     private var longPressTimer: Timer?
     private var longPressTime: Float = 0.0
+
+    let pomodoroTimeManager = PomodoroTimeManager.shared
 
     private let timeLabel = UILabel().then {
         $0.textAlignment = .center
@@ -69,7 +69,13 @@ final class MainViewController: UIViewController {
         addSubviews()
         setupConstraints()
 
-        longPressSetting(isEnable: false)
+        print("Current: \(pomodoroTimeManager.currentTime), Max: \(pomodoroTimeManager.maxTime)")
+        if pomodoroTimeManager.maxTime > pomodoroTimeManager.currentTime {
+            updateTimeLabel()
+            startTimer()
+        }
+
+        setupLongPress(isEnable: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -79,8 +85,8 @@ final class MainViewController: UIViewController {
     }
 
     private func updateTimeLabel() {
-        let minutes = (maxTime - currentTime) / 60
-        let seconds = (maxTime - currentTime) % 60
+        let minutes = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) / 60
+        let seconds = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) % 60
         timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
 
         if let id = notificationId {
@@ -98,7 +104,7 @@ extension MainViewController {
         presentPanModal(modalViewController)
     }
 
-    private func longPressSetting(isEnable: Bool) {
+    private func setupLongPress(isEnable: Bool) {
         let longPressGestureRecognizer = UILongPressGestureRecognizer(
             target: self,
             action: #selector(handleLongPress)
@@ -146,8 +152,8 @@ extension MainViewController {
 
     @objc private func stopTimer() {
         timer?.invalidate()
-        currentTime = 0
-        maxTime = 0
+        pomodoroTimeManager.currentTime = 0
+        pomodoroTimeManager.maxTime = 0
         updateTimeLabel()
         longPressGuideLabel.isHidden = true
         countButton.isHidden = false
@@ -160,28 +166,29 @@ extension MainViewController {
     }
 
     @objc private func startTimer() {
+        print("CurrentTime: \(pomodoroTimeManager.currentTime), MaxTime: \(pomodoroTimeManager.maxTime)")
         longPressTime = 0.0
         progressBar.progress = 0.0
 
-        longPressSetting(isEnable: true)
+        setupLongPress(isEnable: true)
 
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
             self.longPressGuideLabel.isHidden = false
             self.countButton.isHidden = true
             self.timeButton.isHidden = true
 
-            let minutes = (self.maxTime - self.currentTime) / 60
-            let seconds = (self.maxTime - self.currentTime) % 60
-
-            self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
-            self.currentTime += 1
-
-            if self.currentTime > self.maxTime {
+            if self.pomodoroTimeManager.currentTime > self.pomodoroTimeManager.maxTime {
                 timer.invalidate()
                 self.longPressGuideLabel.isHidden = true
                 self.countButton.isHidden = false
                 self.timeButton.isHidden = false
             }
+            self.pomodoroTimeManager.currentTime += 1
+
+            let minutes = (self.pomodoroTimeManager.maxTime - self.pomodoroTimeManager.currentTime) / 60
+            let seconds = (self.pomodoroTimeManager.maxTime - self.pomodoroTimeManager.currentTime) % 60
+
+            self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
         }
         timer?.fire()
 
@@ -195,7 +202,7 @@ extension MainViewController {
             identifier: notificationId!,
             content: content,
             trigger: UNTimeIntervalNotificationTrigger(
-                timeInterval: TimeInterval(maxTime),
+                timeInterval: TimeInterval(pomodoroTimeManager.maxTime),
                 repeats: false
             )
         )
@@ -261,6 +268,6 @@ extension TagModalViewController: PanModalPresentable {
 
 extension MainViewController: TimeSettingViewControllerDelegate {
     func didSelectTime(time: Int) {
-        maxTime = time * 60
+        pomodoroTimeManager.maxTime = time * 60
     }
 }

--- a/Sources/Model/PomodoroTimeManager.swift
+++ b/Sources/Model/PomodoroTimeManager.swift
@@ -1,0 +1,67 @@
+//
+//  PomodoroTimeManager.swift
+//  Pomodoro
+//
+//  Created by 김현기 on 2/13/24.
+//
+
+import Foundation
+import UIKit
+
+class PomodoroTimeManager {
+    static let shared = PomodoroTimeManager()
+
+    private init() {}
+
+    private let userDefaults = UserDefaults.standard
+
+    var currentTime = 0
+    var maxTime = 0
+    private var elapsedTime = 0
+
+    func saveTimerInfo() {
+        // 현재 실제 시각 및 남은 타이머 시간 정보 저장
+        print("SAVE INFOS..")
+        let realTime = Date()
+        elapsedTime = 0
+
+        userDefaults.set(realTime, forKey: "realTime")
+        userDefaults.set(currentTime, forKey: "currentTime")
+        userDefaults.set(maxTime, forKey: "maxTime")
+    }
+
+    func restoreTimerInfo() {
+        // 앱 재시작 시에 타이머 정보 불러오기
+        guard let previousTime = userDefaults.object(forKey: "realTime") as? Date,
+              let reCurrentTime = userDefaults.object(forKey: "currentTime") as? Int,
+              let reMaxTime = userDefaults.object(forKey: "maxTime") as? Int
+        else {
+            return
+        }
+
+        // 재시작 시 현재 시간
+        let realTime = Date()
+        // 남은 시간
+        elapsedTime = Int(realTime.timeIntervalSince(previousTime))
+        let updatedCurrTime = reCurrentTime + elapsedTime
+        maxTime = reMaxTime
+
+        print("TIMER INVALIDATE")
+
+        // 타이머 업데이트
+        print("elapsedTime: \(elapsedTime), updatedTime: \(updatedCurrTime)")
+        print("maxTime: \(maxTime), currentTime: \(currentTime)")
+        if maxTime > updatedCurrTime {
+            currentTime = updatedCurrTime
+        } else {
+            maxTime = 0
+            currentTime = 0
+        }
+    }
+
+    var isTimerExpired: Bool {
+        // 남은 타이머 시간 초과 여부 확인
+//        return (maxTime < currentTime)
+        false
+    }
+}


### PR DESCRIPTION
- [x] 강제 앱 종료 (아이폰에서 앱 실행을 종료하는 상황) 시에 진행되고 있던 시간의 타임스탬프를 저장하기
- [x] 다시 앱을 실행 시켰을 때 저장되어있던 타임스탬프를 가져와서 흐른 시간 이후로 실행시키기

## 문제점
1. 강제종료하는 방법에 따라 강제종료시 함수가 호출이 안되는 현상 발생
2. 별개 문제인데 앱 백그라운드 상황에서 시각 라벨이 업데이트안되는 현상 발견