### PR TITLE
Fix : 일별 참여일, default 날짜 형식 수정

### DIFF
--- a/Pomodoro.xcodeproj/project.pbxproj
+++ b/Pomodoro.xcodeproj/project.pbxproj
@@ -262,8 +262,8 @@
 			isa = PBXGroup;
 			children = (
 				CEDCA0F62B67D015005C18EA /* MockData.swift */,
-				213F30522B6BE72300FAF5F2 /* DashboardPieChartCell.swift */,
 				213F30542B6BE73900FAF5F2 /* DashboardStatusCell.swift */,
+				213F30522B6BE72300FAF5F2 /* DashboardPieChartCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/Sources/DashBoardScene/ViewControllers/DashboardBaseViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DashboardBaseViewController.swift
@@ -38,6 +38,7 @@ class DashboardBaseViewController: UIViewController {
         setupDateLabel()
         setupArrowButtons()
         setupCollectionView()
+        updateSelectedDateFormat()
     }
 
     let dateFormatter = DateFormatter().then {
@@ -104,7 +105,6 @@ class DashboardBaseViewController: UIViewController {
             return
         }
         selectedDate = previousDate
-
         updateSelectedDateFormat()
         delegate?.dateArrowButtonDidTap(data: selectedDate)
         dashboardStatusCell.dateArrowButtonDidTap(data: selectedDate)

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -17,6 +17,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         view.layer.cornerRadius = 20
         view.backgroundColor = .systemGray3
     }
+
     private let donutPieChartView = PieChartView().then { chart in
         chart.noDataText = "출력 데이터가 없습니다."
         chart.noDataFont = .systemFont(ofSize: 20)
@@ -33,11 +34,12 @@ final class DashboardPieChartCell: UICollectionViewCell {
         chart.highlightPerTapEnabled = false
         chart.chartDescription.textColor = .red
     }
-    
+
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError()
     }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         contentView.addSubview(pieBackgroundView)
@@ -47,6 +49,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         setupPieChart()
         setPieChartData(for: Date(), dateType: .day)
     }
+
     private func calculateFocusTimePerTag(for selectedDate: Date) -> [String: Int] {
         let calendar = Calendar.current
         var focusTimePerTag = [String: Int]()
@@ -58,6 +61,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return focusTimePerTag
     }
+
     private func setupPieChart() {
         pieBackgroundView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()
@@ -68,6 +72,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
             make.width.height.equalToSuperview().multipliedBy(1.1)
         }
     }
+
     private func entryData(values: [Double]) -> [ChartDataEntry] {
         var pieDataEntries: [ChartDataEntry] = []
         for index in 0 ..< values.count {
@@ -76,6 +81,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return pieDataEntries
     }
+
     private func calculateFocusTimePerTag(from startDate: Date, to endDate: Date) -> [String: Int] {
         var focusTimePerTag = [String: Int]()
         let filteredSessions = PomodoroData.dummyData.filter { session in
@@ -86,6 +92,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return focusTimePerTag
     }
+
     func setPieChartData(for date: Date, dateType: DashboardDateType) {
         let (startDate, endDate) = getDateRange(for: date, dateType: dateType)
         let focusTimePerTag = calculateFocusTimePerTag(from: startDate, to: endDate)
@@ -101,6 +108,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         let totalFocusTime = focusTimePerTag.reduce(0) { $0 + $1.value }
         updatePieChartText(totalFocusTime: totalFocusTime)
     }
+
     private func updatePieChartText(totalFocusTime: Int) {
         let days = totalFocusTime / (24 * 60)
         let hours = (totalFocusTime % (24 * 60)) / 60
@@ -115,6 +123,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         totalTimeText += "\(minutes)분"
         donutPieChartView.centerText = totalTimeText
     }
+
     private func getDateRange(for date: Date, dateType: DashboardDateType) -> (start: Date, end: Date) {
         let calendar = Calendar.current
         switch dateType {

--- a/Sources/MainScene/ViewControllers/MainPageViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainPageViewController.swift
@@ -40,7 +40,6 @@ final class MainPageViewController: UIViewController {
     private func setupPageViewController() {
         addChild(pageViewController)
         view.addSubview(pageViewController.view)
-
         pageViewController.view.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -107,8 +107,9 @@ extension TagModalViewController: UICollectionViewDataSource, UICollectionViewDe
     func collectionView(
         _ collectionView: UICollectionView,
         layout _: UICollectionViewLayout,
-        sizeForItemAt _: IndexPath) ->
-    CGSize {
+        sizeForItemAt _: IndexPath
+    ) ->
+        CGSize {
         let padding: CGFloat = 10
         let totalPadding = padding * (2 - 1)
         let individualPadding = totalPadding / 2


### PR DESCRIPTION
# ✅ 관련 issue
close #121 

# 🗣 설명

<img width="298" alt="스크린샷 2024-02-19 오전 12 49 48" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/85f3f6c0-3908-42cf-bfd3-0da502dfb052">


<br>

## **📋 체크리스트**
구현해야하는 이슈 체크리스트

- [X]  일별 참여일만 다른 탭과 로직이 다릅니다. 참여일에 대한 로직을 수정해야합니다.
- [X]  앱을 실행하고 나서 가장 처음에 보여지는 date 형식이 모두 통일되어 있습니다. 이를 탭별 case에 맞게 수정해야 합니다.




## 기타
