### PR TITLE
[Feat] #120 강제 앱 종료 시 타임스탬프 적용하기

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -25,21 +25,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             completionHandler: { _, _ in }
         )
 
-        // 앱 재시작될 때
-        print("APP INITIALIZE..")
         pomodoroTimeManager.restoreTimerInfo()
-//        pomodoroTimeManager.startTimer()
-
         return true
     }
 
     func applicationWillTerminate(_: UIApplication) {
-        print("TERMINATE")
-        pomodoroTimeManager.saveTimerInfo()
-    }
-
-    func applicationDidEnterBackground(_: UIApplication) {
-        print("ENTER BACKGROUND")
         pomodoroTimeManager.saveTimerInfo()
     }
 

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -205,45 +205,6 @@ extension MainViewController {
 
             self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
         })
-
-//        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-//            self.longPressGuideLabel.isHidden = false
-//            self.countButton.isHidden = true
-//            self.timeButton.isHidden = true
-//
-//            self.pomodoroTimeManager.setupCurrentTime(curr: self.pomodoroTimeManager.currentTime + 1)
-//
-//            let minutes = (self.pomodoroTimeManager.maxTime - self.pomodoroTimeManager.currentTime) / 60
-//            let seconds = (self.pomodoroTimeManager.maxTime - self.pomodoroTimeManager.currentTime) % 60
-//
-//            if minutes == 0, seconds == 0 {
-//                timer.invalidate()
-//                self.longPressGuideLabel.isHidden = true
-//                self.countButton.isHidden = false
-//                self.timeButton.isHidden = false
-//            }
-//
-//            self.timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
-//        }
-//        timer?.fire()
-
-//        notificationId = UUID().uuidString
-//
-//        let content = UNMutableNotificationContent()
-//        content.title = "시간 종료!"
-//        content.body = "시간이 종료되었습니다. 휴식을 취해주세요."
-//
-//        let request = UNNotificationRequest(
-//            identifier: notificationId!,
-//            content: content,
-//            trigger: UNTimeIntervalNotificationTrigger(
-//                timeInterval: TimeInterval(pomodoroTimeManager.maxTime),
-//                repeats: false
-//            )
-//        )
-//
-//        UNUserNotificationCenter.current()
-//            .add(request)
     }
 }
 

--- a/Sources/Model/PomodoroTimeManager.swift
+++ b/Sources/Model/PomodoroTimeManager.swift
@@ -6,62 +6,48 @@
 //
 
 import Foundation
-import UIKit
 
-class PomodoroTimeManager {
+final class PomodoroTimeManager {
     static let shared = PomodoroTimeManager()
 
     private init() {}
 
     private let userDefaults = UserDefaults.standard
 
-    var currentTime = 0
+    private(set) var currentTime = 0
+
+    func setupCurrentTime(curr: Int) {
+        currentTime = curr
+    }
+
     var maxTime = 0
-    private var elapsedTime = 0
 
     func saveTimerInfo() {
-        // 현재 실제 시각 및 남은 타이머 시간 정보 저장
-        print("SAVE INFOS..")
-        let realTime = Date()
-        elapsedTime = 0
+        let lastSavedDate = Date.now
 
-        userDefaults.set(realTime, forKey: "realTime")
+        userDefaults.set(lastSavedDate, forKey: "realTime")
         userDefaults.set(currentTime, forKey: "currentTime")
         userDefaults.set(maxTime, forKey: "maxTime")
     }
 
     func restoreTimerInfo() {
-        // 앱 재시작 시에 타이머 정보 불러오기
         guard let previousTime = userDefaults.object(forKey: "realTime") as? Date,
-              let reCurrentTime = userDefaults.object(forKey: "currentTime") as? Int,
-              let reMaxTime = userDefaults.object(forKey: "maxTime") as? Int
+              let existCurrentTime = userDefaults.object(forKey: "currentTime") as? Int,
+              let existMaxTime = userDefaults.object(forKey: "maxTime") as? Int
         else {
             return
         }
 
-        // 재시작 시 현재 시간
-        let realTime = Date()
-        // 남은 시간
-        elapsedTime = Int(realTime.timeIntervalSince(previousTime))
-        let updatedCurrTime = reCurrentTime + elapsedTime
-        maxTime = reMaxTime
+        let realTime = Date.now
 
-        print("TIMER INVALIDATE")
+        let updatedCurrTime = existCurrentTime + Int(realTime.timeIntervalSince(previousTime))
+        maxTime = existMaxTime
 
-        // 타이머 업데이트
-        print("elapsedTime: \(elapsedTime), updatedTime: \(updatedCurrTime)")
-        print("maxTime: \(maxTime), currentTime: \(currentTime)")
         if maxTime > updatedCurrTime {
             currentTime = updatedCurrTime
         } else {
             maxTime = 0
             currentTime = 0
         }
-    }
-
-    var isTimerExpired: Bool {
-        // 남은 타이머 시간 초과 여부 확인
-//        return (maxTime < currentTime)
-        false
     }
 }


### PR DESCRIPTION
- [x] 피드백 사항 적용
- [x] 잔버그들 다 고침

### 시연 영상

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/61077215/0936770e-3649-4df4-a55c-cab324f515f9

발견한 문제점
1. 리팩토링 이후 카운트 시작 시 빠릿하게 바로 타이머가 가는게 아니라 1-2초 정도의 딜레이 이후 시간초가 가기 시작함.
2. 영상을 보면 아시겠지만 처음 카운트 이후 종료 후에 다시 시간을 설정하면 설정한 시간보다 1초 작은 값들이 설정됨. 코드 상에는 따로 그런 문제가 없는 것으로 보이는데 원인을 모르겠음.

이 정도 인거 같은데 문제점 1 같은 경우는 제 코드가 문제인가 싶어서 한번 봐주시면 감사하겠습니다..!
