### PR TITLE
[feat] 타이머 설정 페이지 - print문 제거 , 분 기준으로 라벨 표기 , 5분이상 선택시 설정완료 버튼 활성화

### DIFF
--- a/Pomodoro.xcodeproj/project.pbxproj
+++ b/Pomodoro.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DC41B432B82667A002FB140 /* PomodoroTimeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC41B422B82667A002FB140 /* PomodoroTimeManager.swift */; };
 		0DF629662B691ABA00BFE39F /* TimerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF629652B691ABA00BFE39F /* TimerCollectionViewCell.swift */; };
 		213F30532B6BE72300FAF5F2 /* DashboardPieChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F30522B6BE72300FAF5F2 /* DashboardPieChartCell.swift */; };
 		213F30552B6BE73900FAF5F2 /* DashboardStatusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213F30542B6BE73900FAF5F2 /* DashboardStatusCell.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0DC41B422B82667A002FB140 /* PomodoroTimeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PomodoroTimeManager.swift; sourceTree = "<group>"; };
 		0DF629652B691ABA00BFE39F /* TimerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerCollectionViewCell.swift; sourceTree = "<group>"; };
 		213F30522B6BE72300FAF5F2 /* DashboardPieChartCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPieChartCell.swift; sourceTree = "<group>"; };
 		213F30542B6BE73900FAF5F2 /* DashboardStatusCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatusCell.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 		CEDCA0F82B67D015005C18EA /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				0DC41B422B82667A002FB140 /* PomodoroTimeManager.swift */,
 				CEDCA0F92B67D015005C18EA /* Pomodoro.swift */,
 				CEDCA0FA2B67D015005C18EA /* TagList.swift */,
 				CEDCA0FB2B67D015005C18EA /* Option.swift */,
@@ -445,7 +448,6 @@
 				CEDCA1192B67D015005C18EA /* DashBoard.swift in Sources */,
 				21B21B842B73E050008FFDCB /* DashboardBaseViewController.swift in Sources */,
 				CEDCA1172B67D015005C18EA /* TagList.swift in Sources */,
-				0DF629682B692E2200BFE39F /* DashboardPieChartCell.swift in Sources */,
 				CEDCA10C2B67D015005C18EA /* TagCollectionViewData.swift in Sources */,
 				CEDCA1182B67D015005C18EA /* Option.swift in Sources */,
 				CEDCA1052B67D015005C18EA /* AppDelegate.swift in Sources */,
@@ -455,7 +457,6 @@
 				CEDCA1012B67D015005C18EA /* SettingViewController.swift in Sources */,
 				CEDCA1032B67D015005C18EA /* LongBreakModalViewController.swift in Sources */,
 				CEDCA1022B67D015005C18EA /* ShortBreakModalViewController.swift in Sources */,
-				0DF6296A2B692E5C00BFE39F /* DashboardStatusCell.swift in Sources */,
 				CEDCA1162B67D015005C18EA /* Pomodoro.swift in Sources */,
 				CEDCA1082B67D015005C18EA /* MainViewController.swift in Sources */,
 				CEDCA10D2B67D015005C18EA /* MainPageViewController.swift in Sources */,
@@ -465,6 +466,7 @@
 				0DF629662B691ABA00BFE39F /* TimerCollectionViewCell.swift in Sources */,
 				CEDCA1072B67D015005C18EA /* TimeSettingViewController.swift in Sources */,
 				213F30552B6BE73900FAF5F2 /* DashboardStatusCell.swift in Sources */,
+				0DC41B432B82667A002FB140 /* PomodoroTimeManager.swift in Sources */,
 				4DC2298A2B7E2C0900D06ABB /* TagConfigurationViewController.swift in Sources */,
 				CEDCA1042B67D015005C18EA /* DataResetModalViewController.swift in Sources */,
 				CEDCA1142B67D015005C18EA /* MockData.swift in Sources */,

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -17,6 +17,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         view.layer.cornerRadius = 20
         view.backgroundColor = .systemGray3
     }
+
     private let donutPieChartView = PieChartView().then { chart in
         chart.noDataText = "출력 데이터가 없습니다."
         chart.noDataFont = .systemFont(ofSize: 20)
@@ -33,11 +34,12 @@ final class DashboardPieChartCell: UICollectionViewCell {
         chart.highlightPerTapEnabled = false
         chart.chartDescription.textColor = .red
     }
-    
+
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError()
     }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         contentView.addSubview(pieBackgroundView)
@@ -47,6 +49,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         setupPieChart()
         setPieChartData(for: Date(), dateType: .day)
     }
+
     private func calculateFocusTimePerTag(for selectedDate: Date) -> [String: Int] {
         let calendar = Calendar.current
         var focusTimePerTag = [String: Int]()
@@ -58,6 +61,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return focusTimePerTag
     }
+
     private func setupPieChart() {
         pieBackgroundView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()
@@ -68,6 +72,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
             make.width.height.equalToSuperview().multipliedBy(1.1)
         }
     }
+
     private func entryData(values: [Double]) -> [ChartDataEntry] {
         var pieDataEntries: [ChartDataEntry] = []
         for index in 0 ..< values.count {
@@ -76,6 +81,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return pieDataEntries
     }
+
     private func calculateFocusTimePerTag(from startDate: Date, to endDate: Date) -> [String: Int] {
         var focusTimePerTag = [String: Int]()
         let filteredSessions = PomodoroData.dummyData.filter { session in
@@ -86,6 +92,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
         return focusTimePerTag
     }
+
     func setPieChartData(for date: Date, dateType: DashboardDateType) {
         let (startDate, endDate) = getDateRange(for: date, dateType: dateType)
         let focusTimePerTag = calculateFocusTimePerTag(from: startDate, to: endDate)
@@ -101,6 +108,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         let totalFocusTime = focusTimePerTag.reduce(0) { $0 + $1.value }
         updatePieChartText(totalFocusTime: totalFocusTime)
     }
+
     private func updatePieChartText(totalFocusTime: Int) {
         let days = totalFocusTime / (24 * 60)
         let hours = (totalFocusTime % (24 * 60)) / 60
@@ -115,6 +123,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         totalTimeText += "\(minutes)분"
         donutPieChartView.centerText = totalTimeText
     }
+
     private func getDateRange(for date: Date, dateType: DashboardDateType) -> (start: Date, end: Date) {
         let calendar = Calendar.current
         switch dateType {

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -85,6 +85,7 @@ final class MainViewController: UIViewController {
     }
 
     private func updateTimeLabel() {
+        print(pomodoroTimeManager.maxTime)
         let minutes = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) / 60
         let seconds = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) % 60
         timeLabel.text = String(format: "%02d:%02d", minutes, seconds)

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -69,7 +69,6 @@ final class MainViewController: UIViewController {
         addSubviews()
         setupConstraints()
 
-        print("Current: \(pomodoroTimeManager.currentTime), Max: \(pomodoroTimeManager.maxTime)")
         if pomodoroTimeManager.maxTime > pomodoroTimeManager.currentTime {
             updateTimeLabel()
             startTimer()
@@ -85,7 +84,6 @@ final class MainViewController: UIViewController {
     }
 
     private func updateTimeLabel() {
-        print(pomodoroTimeManager.maxTime)
         let minutes = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) / 60
         let seconds = (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) % 60
         timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
@@ -131,7 +129,6 @@ extension MainViewController {
             progressBar.isHidden = true
             longPressTime = 0.0
             progressBar.progress = 0.0
-
             longPressTimer?.invalidate()
         }
     }
@@ -167,7 +164,6 @@ extension MainViewController {
     }
 
     @objc private func startTimer() {
-        print("CurrentTime: \(pomodoroTimeManager.currentTime), MaxTime: \(pomodoroTimeManager.maxTime)")
         longPressTime = 0.0
         progressBar.progress = 0.0
 

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -107,7 +107,9 @@ protocol TagCreationDelegate: AnyObject {
     func didCreateTag(tag: String)
 }
 
-extension TagModalViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, TagCreationDelegate {
+extension TagModalViewController: UICollectionViewDataSource,
+    UICollectionViewDelegateFlowLayout,
+    TagCreationDelegate {
     func collectionView(
         _ collectionView: UICollectionView,
         layout _: UICollectionViewLayout,

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -111,8 +111,9 @@ extension TagModalViewController: UICollectionViewDataSource, UICollectionViewDe
     func collectionView(
         _ collectionView: UICollectionView,
         layout _: UICollectionViewLayout,
-        sizeForItemAt _: IndexPath) ->
-    CGSize {
+        sizeForItemAt _: IndexPath
+    ) ->
+        CGSize {
         let padding: CGFloat = 10
         let totalPadding = padding * (2 - 1)
         let individualPadding = totalPadding / 2

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -165,10 +165,10 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
         guard let centerIndexPathCalculation = collectionView.indexPathForItem(at: center) else {
             return
         }
-
-        let hours = centerIndexPathCalculation.item / 60
-        let minutes = centerIndexPathCalculation.item % 60
-        titleTime.text = String(format: "%02d:%02d", hours, minutes)
+        let currentTimeInMinutes = centerIndexPathCalculation.item * 60
+        let minutes = currentTimeInMinutes / 60
+        let seconds = currentTimeInMinutes % 60
+        titleTime.text = String(format: "%02d:%02d", minutes, seconds)
 
         if centerIndexPath != centerIndexPathCalculation {
             centerIndexPath = centerIndexPathCalculation

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -18,6 +18,7 @@ final class TimeSettingViewController: UIViewController {
     private var centerIndexPath: IndexPath?
     private let timeSelectRange = 5
     var selectedTime: Int = 0
+
     private var isHiddenTimeButton = true {
         didSet {
             timeSettingbutton.isHidden = isHiddenTimeButton
@@ -44,7 +45,7 @@ final class TimeSettingViewController: UIViewController {
         $0.setTitle("설정 완료", for: .normal)
         $0.setTitleColor(.black, for: .normal)
         $0.isHidden = isHiddenTimeButton
-        $0.addTarget(self, action: #selector(onClick), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(onClickTimerSetting), for: .touchUpInside)
     }
 
     private var titleTime = UILabel().then {
@@ -101,9 +102,10 @@ final class TimeSettingViewController: UIViewController {
         }
     }
 
-    @objc private func onClick() {
+    @objc private func onClickTimerSetting() {
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
-        navigationController?.popViewController(animated: true)
+        let tagViewController = TagModalViewController()
+        navigationController?.pushViewController(tagViewController, animated: true)
     }
 }
 
@@ -200,12 +202,8 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
         updateCellPositions()
         print(indexPath.row)
         if indexPath.row >= 5 {
-            print("현재 버튼 상태 : " + String(isHiddenTimeButton))
-            print("-----------------------------------")
             isHiddenTimeButton = false
         } else {
-            print("현재 버튼 상태 : " + String(isHiddenTimeButton))
-            print("-----------------------------------")
             isHiddenTimeButton = true
         }
     }

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -18,6 +18,11 @@ final class TimeSettingViewController: UIViewController {
     private var centerIndexPath: IndexPath?
     private let timeSelectRange = 5
     var selectedTime: Int = 0
+    private var isHiddenTimeButton = true {
+        didSet {
+            timeSettingbutton.isHidden = isHiddenTimeButton
+        }
+    }
 
     private weak var delegate: TimeSettingViewControllerDelegate?
 
@@ -38,6 +43,7 @@ final class TimeSettingViewController: UIViewController {
     private lazy var timeSettingbutton = UIButton().then {
         $0.setTitle("설정 완료", for: .normal)
         $0.setTitleColor(.black, for: .normal)
+        $0.isHidden = isHiddenTimeButton
         $0.addTarget(self, action: #selector(onClick), for: .touchUpInside)
     }
 
@@ -103,7 +109,7 @@ final class TimeSettingViewController: UIViewController {
 
 extension TimeSettingViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_: UICollectionView, numberOfItemsInSection _: Int) -> Int {
-        100
+        150
     }
 
     func collectionView(
@@ -190,8 +196,18 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
         }
     }
 
-    func collectionView(_: UICollectionView, didSelectItemAt _: IndexPath) {
+    func collectionView(_: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         updateCellPositions()
+        print(indexPath.row)
+        if indexPath.row >= 5 {
+            print("현재 버튼 상태 : " + String(isHiddenTimeButton))
+            print("-----------------------------------")
+            isHiddenTimeButton = false
+        } else {
+            print("현재 버튼 상태 : " + String(isHiddenTimeButton))
+            print("-----------------------------------")
+            isHiddenTimeButton = true
+        }
     }
 
     func updateCellPositions() {
@@ -199,6 +215,8 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
             x: collectionView.contentOffset.x + (collectionView.bounds.width / 2),
             y: collectionView.bounds.height / 2
         )
+
+        selectTimeHiddenTimeButton()
 
         guard let centerIndexPathCalculation = collectionView.indexPathForItem(at: center) else {
             return
@@ -222,6 +240,23 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
         if centerIndexPath != centerIndexPathCalculation {
             centerIndexPath = centerIndexPathCalculation
             collectionView.reloadData()
+        }
+    }
+
+    func selectTimeHiddenTimeButton() {
+        let center = CGPoint(
+            x: collectionView.contentOffset.x + (collectionView.bounds.width / 2),
+            y: collectionView.bounds.height / 2
+        )
+
+        guard let centerIndexPathCalculation = collectionView.indexPathForItem(at: center) else {
+            return
+        }
+
+        if centerIndexPathCalculation.row >= 3 {
+            isHiddenTimeButton = false
+        } else {
+            isHiddenTimeButton = true
         }
     }
 }

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -200,7 +200,6 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
 
     func collectionView(_: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         updateCellPositions()
-        print(indexPath.row)
         if indexPath.row >= 5 {
             isHiddenTimeButton = false
         } else {


### PR DESCRIPTION
Done
===================
https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/122281984/254cc1e9-c04f-47fa-b136-fbb39fe4b6ec

- [x] 분 기준으로 라벨 표기
- [x] 5분 이상 선택시 설정 완료 버튼 활성화
- [x] 설정완료 터치시 태그 설정하기 페이지로 감
- [x] 타이머 선택후 홈 화면에 데이터 넘기기
- [x] print문 제거 

기타
====================
issue 추가가 있습니다.
피그마 확인해보니 설정완료 선택시 태그 설정하기로 가기에 태그 설정하기 페이지로 가게끔 했습니다.