### PR TITLE
[Fix] 폰트관련 이슈 수정

### DIFF
--- a/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "84fd06c9cfc62163500b565ecf3e091a3feea574f535adb369f4743cde262a6b",
   "pins" : [
     {
       "identity" : "charts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/danielgindi/Charts.git",
       "state" : {
-        "revision" : "dd9c72e3d7e751e769971092a6bd72d39198ae63",
-        "version" : "5.1.0"
+        "revision" : "0a229f8c914b0ec93798cee058cf75b339297513",
+        "version" : "5.0.0"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HGU-iOS-Study-Group/PomodoroDesignSystem.git",
       "state" : {
-        "revision" : "ec0148f96e93df6aff56bfa12ef52715861529f6",
-        "version" : "0.0.4"
+        "revision" : "72ea160c95abaab787843c21e0df34f60aa69dee",
+        "version" : "0.0.5"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
-        "revision" : "e7f82d1721d99c7149a0af3d0424df9070a1a646",
-        "version" : "10.48.1"
+        "revision" : "55466ae0fb29c5f21866792f05c1fc0c590d7c29",
+        "version" : "10.47.0"
       }
     },
     {
@@ -55,5 +56,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options: [.alert, .sound, .badge],
             completionHandler: { _, _ in }
         )
-        
+
         if let defaultFont = UIFont(name: "BMHANNA11yrsoldOTF", size: 17) {
             let attributes = [NSAttributedString.Key.font: defaultFont]
             UINavigationBar.appearance().titleTextAttributes = attributes

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -24,6 +24,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options: [.alert, .sound, .badge],
             completionHandler: { _, _ in }
         )
+        
+        if let defaultFont = UIFont(name: "BMHANNA11yrsoldOTF", size: 17) {
+            let attributes = [NSAttributedString.Key.font: defaultFont]
+            UINavigationBar.appearance().titleTextAttributes = attributes
+        }
 
         pomodoroTimeManager.restoreTimerInfo()
         return true

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -66,14 +66,8 @@ final class TimeSettingViewController: UIViewController {
         $0.font = .pomodoroFont.text3()
     }
 
-    private lazy var timeSettingbutton = UIButton().then {
-        $0.setTitle("설정 완료", for: .normal)
-        $0.titleLabel?.font = .pomodoroFont.heading3()
-        $0.setTitleColor(.white, for: .normal)
-        $0.layer.cornerRadius = 60 / 2
-        $0.layer.masksToBounds = true
-        $0.backgroundColor = .pomodoro.blackHigh
-        $0.addTarget(self, action: #selector(onClickTimerSetting), for: .touchUpInside)
+    private lazy var confirmButton = PomodoroConfirmButton(title: "설정 완료") { [weak self] in
+        self?.didTapConfirmButton()
     }
 
     private var titleTime = UILabel().then {
@@ -117,7 +111,7 @@ final class TimeSettingViewController: UIViewController {
         view.addSubview(timerImageView)
         view.addSubview(explanationLabel)
         view.addSubview(collectionView)
-        view.addSubview(timeSettingbutton)
+        view.addSubview(confirmButton)
     }
 
     private func setupConstraints() {
@@ -153,7 +147,7 @@ final class TimeSettingViewController: UIViewController {
             make.width.equalTo(308)
             make.height.equalTo(78)
         }
-        timeSettingbutton.snp.makeConstraints { make in
+        confirmButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-170)
             make.width.equalTo(212)
@@ -175,7 +169,7 @@ final class TimeSettingViewController: UIViewController {
         endTimeLabel.text = self.endTime ?? ""
     }
 
-    @objc private func onClickTimerSetting() {
+    private func didTapConfirmButton() {
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
         // router 시작..입니다..?
         dismiss(animated: true)


### PR DESCRIPTION
- PomodoroConfirmButton 의 기본 폰트를 배민하나체로 변경해서 패키지 버전을 업데이트 헀습니다.
- TimeSettingViewController에서 디자인 시스템 버튼이 아니라 직접 구현된 버튼이 있어 대체했습니다.
- 앱 내비게이션 바의 기본 폰트를 배민 하나체로 설정했습니다.



|시간 설정|태그 설정|
|:-:|:-:|
|![simulator_screenshot_BECB8F42-8951-40A9-BE47-30E42A1FBFFE](https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/46087477/cd86d05e-ddee-4265-b96b-e2deaa10ee3f)|![simulator_screenshot_92A609DC-EB19-4048-8A11-98A759879C57](https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/46087477/5f5247ed-1e9f-4737-9930-2f34829fc96d)|