### PR TITLE
[feat] 뽀모도로 긴 휴식 플로우 추가

### DIFF
--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -13,7 +13,7 @@ final class BreakTimerViewController: UIViewController {
     private var timer: Timer?
     private var notificationId: String?
     private var currentTime = 0
-    private var maxTime = 1 * 60
+    private lazy var maxTime: Int = stepManager.timeSetting.setUpBreakTime()
     private var timerHeightConstraint: Constraint?
     var stepManager = PomodoroStepManger()
     private let timeLabel = UILabel().then {
@@ -68,7 +68,6 @@ final class BreakTimerViewController: UIViewController {
         setupConstraints()
         startTimer()
         startAnimationTimer()
-
         setupLongPressGestureRecognizer()
     }
 

--- a/Sources/Common/Managers/PomodoroStepStateManager.swift
+++ b/Sources/Common/Managers/PomodoroStepStateManager.swift
@@ -10,7 +10,7 @@ import UIKit
 class PomodoroStepManger {
     var router = PomodoroRouter.shared
     var label = PomodoroStepLabel()
-    var timeSetting = PomodoroStepTimeChage()
+    var timeSetting = PomodoroStepTimeChange()
 
     func setRouterObservers() {
         router.addObservers(observer: label)

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -26,6 +26,7 @@ final class MainViewController: UIViewController {
 
     lazy var currentStepLabel = UILabel().then {
         $0.text = stepManager.label.setUpLabelInCurrentStep(currentStep: stepManager.router.currentStep)
+        $0.font = .pomodoroFont.heading3()
         $0.textAlignment = .center
     }
 
@@ -251,9 +252,7 @@ extension MainViewController {
     }
 
     @objc private func setPomodoroTime() {
-        stepManager.router.currentStep = .start
-        stepManager.timeSetting.initPomodoroStep()
-        setUpPomodoroCurrentStepLabel()
+        print("set pomodorotime")
         let timeSettingViewController = TimeSettingViewController(isSelectedTime: false, delegate: self)
         if let sheet = timeSettingViewController.sheetPresentationController {
             sheet.detents = [
@@ -290,11 +289,11 @@ extension MainViewController {
         if isStopped == false {
             startTimerLabel.isHidden = true
             startTimerButton.isHidden = true
-            timeLabelTapGestureRecognizer.isEnabled = false
+            timeLabelTapGestureRecognizer.isEnabled = true
         } else {
             startTimerLabel.isHidden = false
             startTimerButton.isHidden = false
-            timeLabelTapGestureRecognizer.isEnabled = false
+            timeLabelTapGestureRecognizer.isEnabled = true
         }
     }
 
@@ -329,7 +328,6 @@ extension MainViewController {
             if minutes == 0, seconds == 0 {
                 timer.invalidate()
                 setupUIWhenTimerStart(isStopped: true)
-
                 database.update(currentPomodoro!) { updatedPomodoro in
                     updatedPomodoro.phase += 1
                     if updatedPomodoro.phase == 5 {
@@ -357,9 +355,7 @@ extension MainViewController {
     }
 
     private func setUpPomodoroCurrentStepLabel() {
-        stepManager.timeSetting.setUptimeInCurrentStep(
-            currentStep: stepManager.router.currentStep
-        )
+        stepManager.timeSetting.setUptimeInCurrentStep()
         currentStepLabel.text = stepManager.label.setUpLabelInCurrentStep(
             currentStep: stepManager.router.currentStep
         )
@@ -383,7 +379,7 @@ extension MainViewController {
     private func setupConstraints() {
         currentStepLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(timeLabel.snp.top).offset(-20)
+            make.bottom.equalTo(timeLabel.snp.top).offset(-23)
         }
         tagButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()

--- a/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
@@ -18,7 +18,9 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
                                                             target: self,
                                                             action: #selector(dismissModal))
     }
+
     // MARK: 태그명 레이블
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.text = "태그명"
@@ -28,21 +30,21 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
     }()
 
     private lazy var textField: UITextField = {
-            let textField = UITextField()
-            textField.borderStyle = .none
-            textField.placeholder = "ex. 공부"
+        let textField = UITextField()
+        textField.borderStyle = .none
+        textField.placeholder = "ex. 공부"
         textField.font = .pomodoroFont.heading6()
-            textField.textAlignment = .left
-            let bottomLine = UIView()
-            bottomLine.backgroundColor = .black
-            textField.addSubview(bottomLine)
-            bottomLine.snp.makeConstraints { make in
-                make.bottom.equalTo(textField.snp.bottom).offset(10)
-                make.left.right.equalTo(textField)
-                make.height.equalTo(2)
-            }
-            return textField
-        }()
+        textField.textAlignment = .left
+        let bottomLine = UIView()
+        bottomLine.backgroundColor = .black
+        textField.addSubview(bottomLine)
+        bottomLine.snp.makeConstraints { make in
+            make.bottom.equalTo(textField.snp.bottom).offset(10)
+            make.left.right.equalTo(textField)
+            make.height.equalTo(2)
+        }
+        return textField
+    }()
 
     // TODO: 태그 생성 폰트 적용
     private lazy var createTagConfirmButton = PomodoroConfirmButton(title: "태그 생성",
@@ -139,7 +141,7 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
         colorPaletteStackView.spacing = 20
         // 2행 4열
         let rows = [UIStackView(), UIStackView()]
-        rows.forEach { row in
+        for row in rows {
             row.axis = .horizontal
             row.distribution = .fillEqually
             row.spacing = 15
@@ -154,20 +156,19 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
                 $0.snp.makeConstraints { make in
                     make.size.equalTo(CGSize(width: 55, height: 55))
                 }
-                    $0.addTarget(self, action: #selector(colorButtonTapped(_:)), for: .touchUpInside)
-                }
-                // 적절한 행에 버튼 추가
-                if index < 4 {
-                    rows[0].addArrangedSubview(colorButton)
-                } else {
-                    rows[1].addArrangedSubview(colorButton)
-                }
+                $0.addTarget(self, action: #selector(colorButtonTapped(_:)), for: .touchUpInside)
+            }
+            // 적절한 행에 버튼 추가
+            if index < 4 {
+                rows[0].addArrangedSubview(colorButton)
+            } else {
+                rows[1].addArrangedSubview(colorButton)
             }
         }
+    }
 
     // TODO: color 버튼 클릭시 정보 전달 로직, 화면상 나타나는 표시(컬러 변경이 더 쉬울 것 같음)
-        @objc private func colorButtonTapped(_ sender: UIButton) {
-            guard let selectedColor = sender.backgroundColor else { return }
-        }
-
+    @objc private func colorButtonTapped(_ sender: UIButton) {
+        guard let selectedColor = sender.backgroundColor else { return }
     }
+}

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -44,6 +44,7 @@ final class TagModalViewController: UIViewController {
         $0.textColor = .black
         $0.font = UIFont.boldSystemFont(ofSize: 15)
     }
+
     private lazy var editTagButton = UIButton().then {
         $0.setTitle("Edit", for: .normal)
         $0.titleLabel?.font = .pomodoroFont.heading5()
@@ -67,7 +68,6 @@ final class TagModalViewController: UIViewController {
         title: "설정 완료",
 //        font: .pomodoroFont.heading2(), // TODO: font 변경
         didTapHandler: didTapSettingCompleteButton
-
     )
 
     override func viewDidLoad() {
@@ -91,7 +91,7 @@ final class TagModalViewController: UIViewController {
 //        }
         // database  에 태그 값 저장.
         database.write(
-                Tag(tagName: "health", tagColor: "two", position: 8))
+            Tag(tagName: "health", tagColor: "two", position: 8))
     }
 
     /// <#Description#>
@@ -208,7 +208,7 @@ final class TagModalViewController: UIViewController {
     @objc func configureTag() {
         let configureTagViewController = TagConfigurationViewController()
         let navigationController = UINavigationController(rootViewController: configureTagViewController)
-        self.present(navigationController, animated: true, completion: nil)
+        present(navigationController, animated: true, completion: nil)
     }
 
     @objc private func didTapSettingCompleteButton() {

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -69,7 +69,7 @@ final class TimeSettingViewController: UIViewController {
     private lazy var confirmButton = PomodoroConfirmButton(title: "설정 완료") { [weak self] in
         self?.didTapConfirmButton()
     }
-  
+
     private var titleTime = UILabel().then {
         $0.font = .pomodoroFont.heading1(size: 80)
         $0.textAlignment = .center

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -66,16 +66,10 @@ final class TimeSettingViewController: UIViewController {
         $0.font = .pomodoroFont.text3()
     }
 
-    private lazy var timeSettingbutton = UIButton().then {
-        $0.setTitle("설정 완료", for: .normal)
-        $0.titleLabel?.font = .pomodoroFont.heading3()
-        $0.setTitleColor(.white, for: .normal)
-        $0.layer.cornerRadius = 60 / 2
-        $0.layer.masksToBounds = true
-        $0.backgroundColor = .pomodoro.blackHigh
-        $0.addTarget(self, action: #selector(onClickTimerSetting), for: .touchUpInside)
-    }
-
+    private lazy var timeSettingbutton = PomodoroConfirmButton(
+        title: "설정 완료",
+        didTapHandler: onClickTimerSetting
+    )
     private var titleTime = UILabel().then {
         $0.font = .pomodoroFont.heading1(size: 80)
         $0.textAlignment = .center
@@ -339,9 +333,9 @@ extension TimeSettingViewController: UIScrollViewDelegate, UICollectionViewDeleg
             y: collectionView.bounds.height / 2
         )
 
-//        guard let centerIndexPathCalculation = collectionView.indexPathForItem(at: center) else {
-//            return
-//        }
+        guard let centerIndexPathCalculation = collectionView.indexPathForItem(at: center) else {
+            return
+        }
     }
 
     func collectionView(

--- a/Sources/SettingsScene/ViewControllers/LongBreakModalViewController.swift
+++ b/Sources/SettingsScene/ViewControllers/LongBreakModalViewController.swift
@@ -11,9 +11,9 @@ import UIKit
 
 final class LongBreakModalViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSource {
     weak var delegate: BreakTimeDelegate?
-
+    weak var setLongDelegate: PomodoroBreakLongSelectionDelegate?
     let database = DatabaseManager.shared
-
+    private let pomodoroStep = PomodoroStepManger()
     private let label = UILabel().then {
         $0.text = "긴 휴식"
         $0.font = .pomodoroFont.heading3()
@@ -41,7 +41,6 @@ final class LongBreakModalViewController: UIViewController, UIPickerViewDelegate
         view.addSubview(label)
         view.addSubview(minutePicker)
         view.addSubview(confirmButton)
-
         minutePicker.sizeToFit()
         minutePicker.delegate = self
         minutePicker.dataSource = self
@@ -109,5 +108,6 @@ final class LongBreakModalViewController: UIViewController, UIPickerViewDelegate
 
     func pickerView(_: UIPickerView, didSelectRow row: Int, inComponent _: Int) {
         tempLongBreakTime = row
+        setLongDelegate?.didSelectLongBreak(time: row + 1)
     }
 }

--- a/Sources/SettingsScene/ViewControllers/SettingViewController.swift
+++ b/Sources/SettingsScene/ViewControllers/SettingViewController.swift
@@ -15,6 +15,14 @@ protocol BreakTimeDelegate: AnyObject {
     func updateTableViewRows()
 }
 
+protocol PomodoroBreakLongSelectionDelegate: AnyObject {
+    func didSelectLongBreak(time: Int)
+}
+
+protocol PomodoroBreakShortSelectionDelegate: AnyObject {
+    func didSelectShortBreak(time: Int)
+}
+
 final class SettingViewController: UIViewController, BreakTimeDelegate {
     let database = DatabaseManager.shared
 

--- a/Sources/SettingsScene/ViewControllers/ShortBreakModalViewController.swift
+++ b/Sources/SettingsScene/ViewControllers/ShortBreakModalViewController.swift
@@ -11,13 +11,14 @@ import UIKit
 
 final class ShortBreakModalViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSource {
     weak var delegate: BreakTimeDelegate?
-
+    weak var setShortDelegate: PomodoroBreakShortSelectionDelegate?
     let database = DatabaseManager.shared
-
     private let label = UILabel().then {
         $0.text = "짧은 휴식"
         $0.font = .pomodoroFont.heading3()
     }
+
+    private let pomodoroStep = PomodoroStepManger()
 
     private lazy var confirmButton = PomodoroConfirmButton(title: "확인", didTapHandler: confirmShortBreakInfo)
 
@@ -41,7 +42,6 @@ final class ShortBreakModalViewController: UIViewController, UIPickerViewDelegat
         view.addSubview(label)
         view.addSubview(minutePicker)
         view.addSubview(confirmButton)
-
         minutePicker.sizeToFit()
         minutePicker.delegate = self
         minutePicker.dataSource = self
@@ -108,5 +108,6 @@ final class ShortBreakModalViewController: UIViewController, UIPickerViewDelegat
 
     func pickerView(_: UIPickerView, didSelectRow row: Int, inComponent _: Int) {
         tempShortBreakTime = row
+        setShortDelegate?.didSelectShortBreak(time: row + 1)
     }
 }


### PR DESCRIPTION
close #214 
#설명

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/122281984/cf333354-63a8-49df-866f-aedc2751d18e

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/122281984/1a9ced73-ddfa-4221-942b-c77b2a7178aa



뽀모도로의 타이머 순환이 마지막으로 오게 되면 휴식 시간은 긴 휴식 플로우로 가져간다. 
추가로 뽀모도로 스텝중 페이지뷰 컨트롤러가 넘어가게끔하기

# Done

- [ ]  뽀모도로 스텝의 마지막 휴식시 긴 휴식 플로우 추가
- [ ] 뽀모도로 스텝중 페이지 넘어가게끔하기

# 기타
뽀모도로 스텝 중 페이지 뷰 컨트롤러가 제대로 작동을 안하고 있었습니다. 즉, 통계페이지와 설정 페이지로 넘어가지 않았습니다!!.
 그래서 페이지 뷰 컨트롤러가 작동하도록 추가했습니다.