### PR TITLE
[Feat] 파이차트 색상과 태그 옆 색상

### DIFF
--- a/Sources/Common/Managers/DatabaseManager.swift
+++ b/Sources/Common/Managers/DatabaseManager.swift
@@ -17,13 +17,13 @@ protocol DataBase {
 
 final class DatabaseManager: DataBase {
     static let shared = DatabaseManager()
-
     private var database: Realm?
 
     private init() {
         print("Database Init")
         do {
             database = try Realm()
+            getLocationOfDefaultRealm()
         } catch {
             print("Error initalizing Realm: \(error)")
         }

--- a/Sources/DashBoardScene/ViewControllers/DashBoardTabViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DashBoardTabViewController.swift
@@ -32,6 +32,25 @@ final class DashBoardTabViewController: UIViewController {
         setupSegmentedControl()
         setupContainerView()
         segmentChanged()
+        tagColorTest()
+    }
+
+    private func tagColorTest() {
+        let testTag: Tag
+        let data = database.read(Pomodoro.self)
+        let tagData = data.first?.currentTag
+        let test = database.read(Tag.self)
+        let tagColor = test.first?.tagName
+
+        if tagData == tagColor {
+            testTag = test.first!
+            print("-=> ", testTag.setupTagTypoColor())
+            print("type === ", type(of: testTag.setupTagTypoColor()))
+        }
+
+        print("---> ", test)
+        print(tagData)
+        print("color : ", tagColor)
     }
 
     private func caculateTotalParticipate() -> Int {

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -171,66 +171,75 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
     }
 
+    private func setupLabels(font: UIFont, textColor: UIColor, text: String? = nil) -> UILabel {
+        let label = UILabel()
+        label.font = font
+        label.textColor = textColor
+        if let text {
+            label.text = text
+        }
+        return label
+    }
+
+    private func setupStackView(axis: NSLayoutConstraint.Axis, spacing: CGFloat = 0) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = axis
+        stackView.spacing = spacing
+        return stackView
+    }
+
+    private func parsingTimes(from focusTime: Int) -> String {
+        let days = focusTime / (24 * 60)
+        let hours = (focusTime % (24 * 60)) / 60
+        let minutes = focusTime % 60
+        var timeText = ""
+        if days > 0 { timeText += "\(days)일 " }
+        if hours > 0 || days > 0 { timeText += "\(hours)시간 " }
+        timeText += "\(minutes)분"
+        return timeText
+    }
+
     private func updateLegendLabel(with focusTimePerTag: [String: Int], tagColors: [String: UIColor]) {
         legendStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let sortedFocusTime = focusTimePerTag.sorted { $0.value > $1.value }
         let totalFocusTime = sortedFocusTime.reduce(0) { $0 + $1.value }
 
         for (tagId, focusTime) in sortedFocusTime {
-            let tagLabel = UILabel()
-            let tagColor = UIView()
-            let timeRatioTextLabel = UILabel()
-            let labelStackView = UIStackView()
-            let labelandColorStackView = UIStackView()
-
-            tagLabel.font = .pomodoroFont.heading5()
-            tagLabel.textColor = .pomodoro.blackHigh
-            timeRatioTextLabel.font = .pomodoroFont.text4()
-            timeRatioTextLabel.textColor = .pomodoro.blackHigh
-            labelStackView.axis = .horizontal
-            labelandColorStackView.spacing = 5
-            labelandColorStackView.axis = .horizontal
-            tagColor.layer.cornerRadius = 7
-            if let color = tagColors[tagId] {
-                tagColor.backgroundColor = color
-            } else {
-                tagColor.backgroundColor = .gray
-            }
-
-            let days = focusTime / (24 * 60)
-            let hours = (focusTime % (24 * 60)) / 60
-            let minutes = focusTime % 60
-            var timeText = ""
-            if days > 0 {
-                timeText += "\(days)일 "
-            }
-            if hours > 0 || days > 0 {
-                timeText += "\(hours)시간 "
-            }
-            timeText += "\(minutes)분"
-            let percentage = (Double(focusTime) / Double(totalFocusTime)) * 100
-
-            tagLabel.text = tagId
-            timeRatioTextLabel.text = "\(timeText) (\(String(format: "%.0f", percentage))%)"
-            timeRatioTextLabel.setAttributedTextColor(
-                targetString: "(\(String(format: "%.0f", percentage))%)", color: UIColor.pomodoro.blackMedium
+            let tagLabel = setupLabels(
+                font: .pomodoroFont.heading5(),
+                textColor: .pomodoro.blackHigh,
+                text: tagId
             )
-            timeRatioTextLabel.textAlignment = .right
-            labelandColorStackView.addArrangedSubview(tagColor)
-            labelandColorStackView.addArrangedSubview(tagLabel)
+            let timeRatioTextLabel = setupLabels(
+                font: .pomodoroFont.text4(),
+                textColor: .pomodoro.blackHigh
+            )
+
+            let tagColor = UIView()
+            tagColor.layer.cornerRadius = 7
+            tagColor.backgroundColor = tagColors[tagId] ?? .gray
             NSLayoutConstraint.activate([
                 tagColor.widthAnchor.constraint(equalToConstant: 15),
                 tagColor.heightAnchor.constraint(equalToConstant: 15)
             ])
+
+            let timeText = parsingTimes(from: focusTime)
+            let percentage = (Double(focusTime) / Double(totalFocusTime)) * 100
+            timeRatioTextLabel.text = "\(timeText) (\(String(format: "%.0f", percentage))%)"
+
+            let labelandColorStackView = setupStackView(axis: .horizontal, spacing: 5)
+            labelandColorStackView.addArrangedSubview(tagColor)
+            labelandColorStackView.addArrangedSubview(tagLabel)
+
+            let labelStackView = setupStackView(axis: .horizontal)
             labelStackView.addArrangedSubview(labelandColorStackView)
             labelStackView.addArrangedSubview(timeRatioTextLabel)
+
             legendStackView.addArrangedSubview(labelStackView)
         }
 
         tagLabelHeightConstraint?.update(offset: 360 + 25 * sortedFocusTime.count)
-        UIView.animate(withDuration: 0) {
-            self.layoutIfNeeded()
-        }
+        UIView.animate(withDuration: 0) { self.layoutIfNeeded() }
     }
 
     private func updatePieChartText(totalFocusTime: Int) {

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -173,8 +173,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
             let labelandColorStackView = UIStackView()
 
             tagLabel.font = .pomodoroFont.heading5()
-            //            tagLabel.textColor = .pomodoro.blackHigh
-            tagLabel.textColor = .red
+            tagLabel.textColor = .pomodoro.blackHigh
             timeRatioTextLabel.font = .pomodoroFont.text4()
             timeRatioTextLabel.textColor = .pomodoro.blackHigh
             labelStackView.axis = .horizontal
@@ -206,10 +205,8 @@ final class DashboardPieChartCell: UICollectionViewCell {
             labelandColorStackView.addArrangedSubview(tagLabel)
             NSLayoutConstraint.activate([
                 tagColor.widthAnchor.constraint(equalToConstant: 15),
-                tagColor.heightAnchor.constraint(equalToConstant: 15),
+                tagColor.heightAnchor.constraint(equalToConstant: 15)
             ])
-//            labelStackView.addArrangedSubview(tagColor)
-//            labelStackView.addArrangedSubview(tagLabel)
             labelStackView.addArrangedSubview(labelandColorStackView)
             labelStackView.addArrangedSubview(timeRatioTextLabel)
             legendStackView.addArrangedSubview(labelStackView)

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -145,7 +145,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
 
         let totalFocusTime = focusTimePerTag.reduce(0) { $0 + $1.value }
         updatePieChartText(totalFocusTime: totalFocusTime)
-        updateLegendLabel(with: focusTimePerTag)
+        updateLegendLabel(with: focusTimePerTag, tagColors: tagColors)
     }
 
     private func setLegendLabel() {
@@ -171,7 +171,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         }
     }
 
-    private func updateLegendLabel(with focusTimePerTag: [String: Int]) {
+    private func updateLegendLabel(with focusTimePerTag: [String: Int], tagColors: [String: UIColor]) {
         legendStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let sortedFocusTime = focusTimePerTag.sorted { $0.value > $1.value }
         let totalFocusTime = sortedFocusTime.reduce(0) { $0 + $1.value }
@@ -191,7 +191,11 @@ final class DashboardPieChartCell: UICollectionViewCell {
             labelandColorStackView.spacing = 5
             labelandColorStackView.axis = .horizontal
             tagColor.layer.cornerRadius = 7
-            tagColor.backgroundColor = .yellow
+            if let color = tagColors[tagId] {
+                tagColor.backgroundColor = color
+            } else {
+                tagColor.backgroundColor = .gray
+            }
 
             let days = focusTime / (24 * 60)
             let hours = (focusTime % (24 * 60)) / 60

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -164,16 +164,24 @@ final class DashboardPieChartCell: UICollectionViewCell {
         legendStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         let sortedFocusTime = focusTimePerTag.sorted { $0.value > $1.value }
         let totalFocusTime = sortedFocusTime.reduce(0) { $0 + $1.value }
+
         for (tagId, focusTime) in sortedFocusTime {
             let tagLabel = UILabel()
+            let tagColor = UIView()
             let timeRatioTextLabel = UILabel()
             let labelStackView = UIStackView()
+            let labelandColorStackView = UIStackView()
 
             tagLabel.font = .pomodoroFont.heading5()
-            tagLabel.textColor = .pomodoro.blackHigh
+            //            tagLabel.textColor = .pomodoro.blackHigh
+            tagLabel.textColor = .red
             timeRatioTextLabel.font = .pomodoroFont.text4()
             timeRatioTextLabel.textColor = .pomodoro.blackHigh
             labelStackView.axis = .horizontal
+            labelandColorStackView.spacing = 5
+            labelandColorStackView.axis = .horizontal
+            tagColor.layer.cornerRadius = 7
+            tagColor.backgroundColor = .yellow
 
             let days = focusTime / (24 * 60)
             let hours = (focusTime % (24 * 60)) / 60
@@ -194,11 +202,19 @@ final class DashboardPieChartCell: UICollectionViewCell {
                 targetString: "(\(String(format: "%.0f", percentage))%)", color: UIColor.pomodoro.blackMedium
             )
             timeRatioTextLabel.textAlignment = .right
-
-            labelStackView.addArrangedSubview(tagLabel)
+            labelandColorStackView.addArrangedSubview(tagColor)
+            labelandColorStackView.addArrangedSubview(tagLabel)
+            NSLayoutConstraint.activate([
+                tagColor.widthAnchor.constraint(equalToConstant: 15),
+                tagColor.heightAnchor.constraint(equalToConstant: 15),
+            ])
+//            labelStackView.addArrangedSubview(tagColor)
+//            labelStackView.addArrangedSubview(tagLabel)
+            labelStackView.addArrangedSubview(labelandColorStackView)
             labelStackView.addArrangedSubview(timeRatioTextLabel)
             legendStackView.addArrangedSubview(labelStackView)
         }
+
         tagLabelHeightConstraint?.update(offset: 360 + 25 * sortedFocusTime.count)
         UIView.animate(withDuration: 0) {
             self.layoutIfNeeded()


### PR DESCRIPTION
# ✅ 관련 issue
close #178 

# 🗣 설명

<img width="266" alt="스크린샷 2024-04-02 오후 11 54 05" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/c7423cc9-5e0b-4dd4-aa94-9de71e0628d7">


<br>

## **📋 체크리스트**
구현해야하는 이슈 체크리스트

- [X] 색상 정책 확인하기
- [X] 태그 옆 색상 보여주기
- [X] 파이차트에서 설정한 색 보여주기



## 기타
- 아직 파이차트 부분이 렘 연결이 안되어 있어 목데이터의 태그 이름과 realm에 만들어둔 tag 이름을 비교하여 색상을 지정하였습니다.
- 다음 PR에서 파이차트부분 렘 연결하도록 하겠습니다.
- 렘의 Tag 클래스에 있는 태그 이름과 Pomodoro 클래스에 있는 태그 이름을 비교하여 그에 맞는 tagColor를 반환해 적용하였습니다.
