### PR TITLE
[Feat] 휴식 효과 해제 시 화면 채워지는 animation 제거하기

### DIFF
--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -74,8 +74,9 @@ final class BreakTimerViewController: UIViewController {
         addSubviews()
         setupConstraints()
         startTimer()
-        isTimerEffect ?
-            startAnimationTimer() : print("timer effect is false")
+        if isTimerEffect {
+            startAnimationTimer()
+        }
         setupLongPressGestureRecognizer()
     }
 

--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -5,11 +5,13 @@
 //  Created by 김하람 on 2/19/24.
 //
 
+import RealmSwift
 import SnapKit
 import Then
 import UIKit
 
 final class BreakTimerViewController: UIViewController {
+    let database = DatabaseManager.shared
     private var timer: Timer?
     private var notificationId: String?
     private var currentTime = 0
@@ -61,13 +63,19 @@ final class BreakTimerViewController: UIViewController {
     }
 
     override func viewDidLoad() {
+        let realmOption = database.read(Option.self).first
+        let isTimer = realmOption?.isTimerEffect
+        guard let isTimerEffect = isTimer else {
+            return print("it is optional")
+        }
         super.viewDidLoad()
         view.backgroundColor = .pomodoro.background
         navigationController?.isNavigationBarHidden = true
         addSubviews()
         setupConstraints()
         startTimer()
-        startAnimationTimer()
+        isTimerEffect ?
+            startAnimationTimer() : print("timer effect is false")
         setupLongPressGestureRecognizer()
     }
 


### PR DESCRIPTION
# ✅ 관련 issue
close #199 

# 🗣 설명

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/6240c99e-7be4-456e-a03e-ddeba434c799





<br>

## **📋 체크리스트**
구현해야하는 이슈 체크리스트

- [X] 휴식 효과 해제 여부
- [X] 휴식 효과 해제 시 animation 제거



## 기타
- 휴식타임 완료시 알림이 자꾸 두 번씩 뜨는데, 이 부분 수정이 필요할 것 같습니다.
- 다음 이슈로 제가 하거나, 현기오빠와 소통 후 해결하겠습니다 !