### PR TITLE
[Feat] 태그 설정 뷰 - 설정완료 버튼 사이즈 수정

### DIFF
--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -66,7 +66,6 @@ final class TagModalViewController: UIViewController {
 
     private lazy var tagSettingCompletedButton = PomodoroConfirmButton(
         title: "설정 완료",
-//        font: .pomodoroFont.heading2(), // TODO: font 변경
         didTapHandler: didTapSettingCompleteButton
     )
 
@@ -112,16 +111,11 @@ final class TagModalViewController: UIViewController {
             make.width.equalToSuperview().multipliedBy(0.8)
         }
         tagSettingCompletedButton.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(45)
-            make.trailing.equalToSuperview().offset(-45)
-            make.bottom.equalToSuperview().offset(-(view.bounds.height * 0.2))
+            make.centerX.equalToSuperview()
+            make.top.equalTo(tagsStackView.snp.bottom).offset(106)
+            make.width.equalTo(212)
+            make.height.equalTo(60)
         }
-        // TODO: 진세 확인버튼 제약조건 참고하기
-//        confirmButton.snp.makeConstraints { make in
-//                   make.centerX.equalToSuperview()
-//                   make.bottom.equalToSuperview().offset(-170)
-//                   make.width.equalTo(212)
-//           }
     }
 
     private func addTagsToStackView() {


### PR DESCRIPTION
# ✅ 관련 issue
close #212 

# 🗣 설명
<img width="262" alt="스크린샷 2024-04-09 오후 5 18 40" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/384f0a0c-b76a-49c1-95d2-c0bb5e796c41">


<br>

## **📋 체크리스트**
구현해야하는 이슈 체크리스트

- [X] 디자인된 버튼 사이즈 측정 후, 사이즈 변경 필요


## 기타
- 피그마 보니까, 태그들 위에 컴포넌트들이 또 있어서 기존 view.bottom을 기준으로 잡혀있던 오토레이아웃을 태그 stackView의 bottom으로부터 피그마 값만큼 떨어지도록 버튼의 top을 설정하였습니다 !