### PR TITLE
[Feat] Tag CRUD 구현

### DIFF
--- a/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
@@ -114,17 +114,18 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
                             else {
                                 return
                             }
-//                            RealmService.write(
-//                                Tag(
-//                                    tagName: text,
-//                                    colorIndex: selectedColorIndex
-//                                )
-//                            )
+                            //                            RealmService.write(
+                            //                                Tag(
+                            //                                    tagName: text,
+                            //                                    colorIndex: selectedColorIndex
+                            //                                )
+                            //                            )
                             RealmService.write(
-                                Tag(tagName: text, 
+                                Tag(tagName: text,
                                     colorIndex: self.selectedColorIndex!,
                                     position: self.calculatePosition())
                             )
+                        // TODO: if 입력한 tagText 가 realm 에 존재한다면, 태그 중복입니다. 팝업창띄우기.
                         }
                     )
                 )

--- a/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagConfigurationViewController.swift
@@ -114,11 +114,16 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
                             else {
                                 return
                             }
+//                            RealmService.write(
+//                                Tag(
+//                                    tagName: text,
+//                                    colorIndex: selectedColorIndex
+//                                )
+//                            )
                             RealmService.write(
-                                Tag(
-                                    tagName: text,
-                                    colorIndex: selectedColorIndex
-                                )
+                                Tag(tagName: text, 
+                                    colorIndex: self.selectedColorIndex!,
+                                    position: self.calculatePosition())
                             )
                         }
                     )
@@ -126,11 +131,39 @@ final class TagConfigurationViewController: UIViewController, UITextFieldDelegat
                 .show(on: self)
             return
         }
-        delegate?.createTag(tag: tagText, color: colorIndex)
+        delegate?.createTag(tag: tagText, color: colorIndex, position: calculatePosition())
         Log.info("->>>>> ", tagText, colorIndex)
-        RealmService.write(Tag(tagName: tagText, colorIndex: colorIndex))
+        RealmService.write(Tag(tagName: tagText, 
+                               colorIndex: colorIndex,
+                               position: calculatePosition()))
         dismiss(animated: true, completion: nil)
     }
+    
+    // MARK: Calculate the position for a new tag
+//    private func calculatePosition() -> Int {
+//        do {
+//            let existingTags = try RealmService.read(Tag.self)
+//            return existingTags.max(ofProperty: "position") ?? 0
+//        } catch {
+//            Log.error("Failed to fetch tags from Realm: \(error)")
+//            return 0
+//        }
+//    }
+    // MARK: Calculate the position for a new tag
+    private func calculatePosition() -> Int {
+        do {
+            let existingTags = try RealmService.read(Tag.self)
+            if let maxPosition = existingTags.max(ofProperty: "position") as Int? {
+                return maxPosition + 1
+            } else {
+                return 0 // 태그가 하나도 없는 경우, 첫 번째 태그의 위치는 0
+            }
+        } catch {
+            Log.error("Failed to fetch tags from Realm: \(error)")
+            return 0
+        }
+    }
+
 
     private func setupViews() {
         closeButton.addTarget(self, action: #selector(dismissModal), for: .touchUpInside)

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -165,7 +165,7 @@ final class TagModalViewController: UIViewController {
 
     private func createRoundButton(title: String, colorIndex: String, tagIndex: Int) -> UIButton {
         Log.info(TagCase(rawValue: colorIndex)?.typoColor ?? .black)
-
+        print("태그 인덱스: \(tagIndex)")
         let button = UIButton().then {
             $0.setTitle(title, for: .normal)
             $0.titleLabel?.font = .pomodoroFont.heading4()
@@ -187,7 +187,7 @@ final class TagModalViewController: UIViewController {
             $0.backgroundColor = .white
             $0.layer.cornerRadius = 10
             $0.isHidden = true // 기본적으로 숨김
-            $0.tag = button.tag  // 위에 버튼과 동일한 태그
+           // $0.tag = button.tag  // 위에 버튼과 동일한 태그
         }
         button.addSubview(minusButton)
 
@@ -201,7 +201,7 @@ final class TagModalViewController: UIViewController {
 
         // MARK: minusButton에 삭제 액션 추가
 
-        minusButton.addTarget(self, action: #selector(deletTag(_:)), for: .touchUpInside)
+        minusButton.addTarget(self, action: #selector(deletTag(tagIndex: tagIndex)), for: .touchUpInside)
 
         return button
     }
@@ -261,27 +261,21 @@ final class TagModalViewController: UIViewController {
 //            )
 //            .show(on: self)
 //    }
-    @objc private func deletTag(_ sender: UIButton) {
-//        let tagIndex = sender.tag
-        let tagIndex = sender.superview?.tag  // 상위 버튼의 태그를 사용합니다.
+    @objc private func deletTag(tagIndex: Int) {
+     //   let tagIndex = sender.superview?.tag  // 상위 버튼 태그 사용.
+        print("상위버튼태그: \(tagIndex)")
         PomodoroPopupBuilder()
             .add(title: "태그 삭제")
             .add(body: "태그를 정말 삭제하시겠습니까? 한 번 삭제한 태그는 다시 되돌릴 수 없습니다.")
             .add(button: .confirm(title: "확인", action: { [weak self] in
                 guard let self = self else { return }
                 do {
-                    // RealmService를 사용하여 태그 데이터 조회 및 삭제
-//                    if let tagToDelete = try? RealmService.read(Tag.self).filter("position == %@", tagIndex).first {
-//                        try RealmService.delete(tagToDelete) // 데이터베이스에서 해당 태그 삭제
-//                        print("Tag at index \(tagIndex) deleted")
+                    if let tagToDelete = try RealmService.read(Tag.self).filter("position == %@", tagIndex).first {
+                        print("Tag at index \(tagIndex) deleted")
+                        RealmService.delete(tagToDelete)
 //                        DispatchQueue.main.async {
 //                            self.addTagsToStackView() // UI 업데이트
-                    if let tagToDelete = try RealmService.read(Tag.self).filter("position == %@", tagIndex).first {
-                        try RealmService.delete(tagToDelete)
-                        print("Tag at index \(tagIndex) deleted")
-                        DispatchQueue.main.async {
-                            self.addTagsToStackView() // UI 업데이트
-                        }
+//                        }
                     } else {
                         print("No tag found at index \(tagIndex)")
                     }
@@ -304,15 +298,14 @@ final class TagModalViewController: UIViewController {
 //    }
     @objc private func createMinusButton() {
         tagSettingCompletedButton.isEnabled.toggle()  // 설정 완료 버튼의 활성화 상태 토글
-        // tagsStackView 내의 모든 버튼을 순회
         for case let button as UIButton in tagsStackView.arrangedSubviews.flatMap(\.subviews) {
-            // 각 버튼의 서브뷰 중에서 UIButton 타입을 찾고, "-" 문자를 가진 버튼이면 minusButton으로 간주
+            // 각 버튼의 서브뷰 중에서 UIButton 타입을 찾고, "-" 문자를 가진 버튼이면 minusButton
             if let minusButton = button.subviews.first(where: { subview in
                 guard let btn = subview as? UIButton else { return false }
                 return btn.title(for: .normal) == "-"
             }) as? UIButton {
-                minusButton.isHidden.toggle()  // minusButton의 가시성 토글
-                button.bringSubviewToFront(minusButton)  // minusButton을 전면으로
+                minusButton.isHidden.toggle()
+                button.bringSubviewToFront(minusButton)
             }
         }
     }

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -20,7 +20,7 @@ protocol TagModalViewControllerDelegate: AnyObject {
     func tagSelected(tag: String)
 }
 
-// TODO: 1. 태그 생성 버튼 클릭시 태그모달뷰에서 바로 태그값 보이게 설정 2.태그 모달뷰에서 선택한 태그 값이 메인뷰에서 보이게 값 전달. 3. 태그 설정 뷰에서 텍스트필드입력값이랑 렘의 태그네임이랑 비교 후, 중복확인 로직.
+// TODO: 2.태그 모달뷰에서 선택한 태그 값이 메인뷰에서 보이게 값 전달.
 
 final class TagModalViewController: UIViewController {
     private weak var selectionDelegate: TagModalViewControllerDelegate?
@@ -71,7 +71,7 @@ final class TagModalViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
-        addTagsToStackView()
+//        addTagsToStackView()
         closeButton.addTarget(self, action: #selector(dismissModal), for: .touchUpInside)
         tagSettingCompletedButton.isEnabled = false // 첫 화면에는 설정완료 비활성화
     }
@@ -137,6 +137,10 @@ final class TagModalViewController: UIViewController {
     }
 // TODO: 1. 렘 미리 읽고, 렘 is empty 이면 default tag realm 에 저장
     private func addTagsToStackView() {
+        tagsStackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+        
         let tagList = try? RealmService.read(Tag.self)
         Log.info("TAGLIST: \(String(describing: tagList))")
         let maxTags = 7
@@ -212,7 +216,8 @@ final class TagModalViewController: UIViewController {
         // MARK: minusButton에 삭제 액션 추가
 // TODO: 여기서 -버튼 클릭시 딜리트태그 함수가 실행됨. 태그가 딜리트 되려면, 일단 그 값을 정확히 삭제해야하는데. -버튼의 태그 값을 명확히 알게 해줄수있는 방법은 없는지?
 //        minusButton.addTarget(self, action: #selector(deletTag(tagIndex: tagIndex)), for: .touchUpInside)
-        minusButton.addTarget(self, action: #selector(deletTag), for: .touchUpInside)
+//        minusButton.addTarget(self, action: #selector(deletTag), for: .touchUpInside)
+        minusButton.addTarget(self, action: #selector(deletTag(sender:)), for: .touchUpInside)
         
 
         return button
@@ -251,15 +256,36 @@ final class TagModalViewController: UIViewController {
     }
 
     // TODO: Tag 삭제 버튼 연결 - realm 에서 tag값 삭제 (만약 값이 들어있는 index 라면, update, 값이 없다면 delete
-    @objc private func deletTag() {
-     //   let tagIndex = sender.superview?.tag  // 상위 버튼 태그 사용.
+//    @objc private func deletTag() {
+//     //   let tagIndex = sender.superview?.tag  // 상위 버튼 태그 사용.
+//        PomodoroPopupBuilder()
+//            .add(title: "태그 삭제")
+//            .add(body: "태그를 정말 삭제하시겠습니까? 한 번 삭제한 태그는 다시 되돌릴 수 없습니다.")
+//            .add(button: .confirm(title: "확인", action: { [weak self] in
+//                guard let self = self else { return }
+//                do {
+//                    if let tagToDelete = try RealmService.read(Tag.self).filter(tagIndex).first {
+//                        print("Tag at index \(tagIndex) deleted")
+//                        RealmService.delete(tagToDelete)
+//                    } else {
+//                        print("No tag found at index \(tagIndex)")
+//                    }
+//                } catch {
+//                    print("Error deleting tag: \(error)")
+//                }
+//            }))
+//            .show(on: self)
+//    }
+    // deletTag 함수 수정
+    @objc private func deletTag(sender: UIButton) {
+        let tagIndex = sender.tag
         PomodoroPopupBuilder()
             .add(title: "태그 삭제")
             .add(body: "태그를 정말 삭제하시겠습니까? 한 번 삭제한 태그는 다시 되돌릴 수 없습니다.")
             .add(button: .confirm(title: "확인", action: { [weak self] in
                 guard let self = self else { return }
                 do {
-                    if let tagToDelete = try RealmService.read(Tag.self).filter(tagIndex).first {
+                    if let tagToDelete = try RealmService.read(Tag.self).filter("position == \(tagIndex)").first {
                         print("Tag at index \(tagIndex) deleted")
                         RealmService.delete(tagToDelete)
                     } else {
@@ -271,9 +297,6 @@ final class TagModalViewController: UIViewController {
             }))
             .show(on: self)
     }
-
-
-
     // TODO: Editbutton 클릭시 - 버튼 활성화 함수
 //    @objc private func createMinusButton() {
 //        tagSettingCompletedButton.isEnabled.toggle()

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -126,7 +126,7 @@ final class TagModalViewController: UIViewController {
             $0.distribution = .fillEqually
         }
     }
-
+// TODO: 1. 렘 미리 읽고, 렘 is empty 이면 default tag realm 에 저장
     private func addTagsToStackView() {
         let tagList = try? RealmService.read(Tag.self)
         Log.info("TAGLIST: \(String(describing: tagList))")

--- a/Sources/Model/Tag.swift
+++ b/Sources/Model/Tag.swift
@@ -60,11 +60,13 @@ enum TagCase: String {
 class Tag: Object {
     @Persisted(primaryKey: true) var tagName: String
     @Persisted var colorIndex: String
+    @Persisted var position: Int // MARK: Tag Model - Position
 
-    convenience init(tagName: String, colorIndex: String) {
+    convenience init(tagName: String, colorIndex: String, position: Int) {
         self.init()
         self.tagName = tagName
         self.colorIndex = colorIndex
+        self.position = position // MARK: Tag Model - Position
     }
 
     func setupTagBackgroundColor() -> UIColor {


### PR DESCRIPTION
- 태그 중복 팝업 기능 구현
- 태그 삭제 기능 구현
- 태그 생성 버튼 클릭 후, 태그값 태그모달뷰에서 바로 보여주기

- [ ] 렘 미리 읽고, 렘 is empty 이면 default tag realm 에 저장
- [ ] 태그 모달뷰에서 선택한 태그 값이 메인뷰에서 보이게 값 전달.
- [ ] color 버튼 클릭시 정보 전달 로직, 화면상 나타나는 표시(컬러 변경이 더 쉬울 것 같음)
- [ ] deletTag 함수 수정 minusButton 클릭시 렘에서 삭제, 화면에서 삭제 addtarget: tag 사용하기
-

![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 20 07 23](https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/90087719/598f0c75-a6b4-456e-9398-6d91fdc037db)
