### PR TITLE
[fix] Realm 적용을 통한 뽀모도로 실패 기록하기 - git 실수로 인해 다시 pr 올립니다.

### DIFF
--- a/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HGU-iOS-Study-Group/PomodoroDesignSystem.git",
       "state" : {
-        "revision" : "ec0148f96e93df6aff56bfa12ef52715861529f6",
-        "version" : "0.0.4"
+        "revision" : "72ea160c95abaab787843c21e0df34f60aa69dee",
+        "version" : "0.0.5"
       }
     },
     {

--- a/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pomodoro.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/HGU-iOS-Study-Group/PomodoroDesignSystem.git",
       "state" : {
-        "revision" : "72ea160c95abaab787843c21e0df34f60aa69dee",
-        "version" : "0.0.5"
+        "revision" : "ec0148f96e93df6aff56bfa12ef52715861529f6",
+        "version" : "0.0.4"
       }
     },
     {

--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -153,7 +153,8 @@ extension BreakTimerViewController {
             navigationController: navigationController ?? UINavigationController()
         )
         // - TODO: do pomodoroStep initialize
-        stepManager.timeSetting.initPomodoroStepInRestTime()
+        stepManager.timeSetting.initPomodoroStep()
+        // stepManager.realmSetting.stopPomodoroStep(time: pomodoroTime.currentTime)
         stepManager.router.currentStep = .start
         longPressGuideLabel.isHidden = true
     }

--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -88,7 +88,6 @@ final class BreakTimerViewController: UIViewController {
         let minutes = (maxTime - currentTime) / 60
         let seconds = (maxTime - currentTime) % 60
         timeLabel.text = String(format: "%02d:%02d", minutes, seconds)
-
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [notificationId])
     }
 }
@@ -154,7 +153,6 @@ extension BreakTimerViewController {
         )
         // - TODO: do pomodoroStep initialize
         stepManager.timeSetting.initPomodoroStep()
-        // stepManager.realmSetting.stopPomodoroStep(time: pomodoroTime.currentTime)
         stepManager.router.currentStep = .start
         longPressGuideLabel.isHidden = true
     }

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -108,6 +108,7 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         stepManager.setRouterObservers()
+        print(stepManager.router.currentStep)
         setUpPomodoroCurrentStepLabel()
         
         let documentsDirectory = NSSearchPathForDirectoriesInDomains(
@@ -257,11 +258,9 @@ extension MainViewController {
                 self.longPressGestureRecognizer.isEnabled = false
             }
 
-            stepManager.timeSetting.stopPomodoroStep(
-                currentTime: pomodoroTimeManager.currentTime
-            )
+            stepManager.timeSetting.setUptimeInCurrentStep()
+//            stepManager.timeSetting.setUpBreakTime()
             currentStepLabel.text = ""
-
             UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
             setupTimeAndTag()
 
@@ -377,6 +376,7 @@ extension MainViewController {
 
     private func setUpPomodoroCurrentStepLabel() {
         stepManager.timeSetting.setUptimeInCurrentStep()
+        // stepManager.realmSetting.setUpRealmInCurrentStep()
         currentStepLabel.text = stepManager.label.setUpLabelInCurrentStep(
             currentStep: stepManager.router.currentStep
         )

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -110,14 +110,12 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         stepManager.setRouterObservers()
-        print(stepManager.router.currentStep)
         setUpPomodoroCurrentStepLabel()
 
         let documentsDirectory = NSSearchPathForDirectoriesInDomains(
             .documentDirectory, .userDomainMask,
             true
         )[0]
-        print(documentsDirectory)
 
         if UserDefaults.standard.object(forKey: "needOnboarding") == nil {
             UserDefaults.standard.set(true, forKey: "needOnboarding")
@@ -248,13 +246,6 @@ extension MainViewController {
 
             longPressTimer?.invalidate()
 
-            if let currentPomodoro {
-                RealmService.update(currentPomodoro) { pomodoro in
-                    pomodoro.phase = 0
-                    pomodoro.isSuccess = false
-                }
-            }
-
             pomodoroTimeManager.stopTimer {
                 setupUIWhenTimerStart(isStopped: true)
                 self.longPressGestureRecognizer.isEnabled = false
@@ -346,15 +337,6 @@ extension MainViewController {
             if minutes == 0, seconds == 0 {
                 timer.invalidate()
                 setupUIWhenTimerStart(isStopped: true)
-                guard let currentPomodoro else { return }
-                RealmService.update(currentPomodoro) { updatedPomodoro in
-                    updatedPomodoro.phase += 1
-                    if updatedPomodoro.phase == 5 {
-                        updatedPomodoro.isSuccess = true
-                        updatedPomodoro.phase = 0
-                    }
-                }
-
                 setUpPomodoroCurrentStep()
 
                 longPressGestureRecognizer.isEnabled = false
@@ -378,11 +360,9 @@ extension MainViewController {
 
     private func setUpPomodoroCurrentStepLabel() {
         stepManager.timeSetting.setUptimeInCurrentStep()
-        // stepManager.realmSetting.setUpRealmInCurrentStep()
         currentStepLabel.text = stepManager.label.setUpLabelInCurrentStep(
             currentStep: stepManager.router.currentStep
         )
-
         if stepManager.router.currentStep != .start {
             timeSettingGuideButton.isHidden = true
         } else {

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -22,7 +22,9 @@ final class MainViewController: UIViewController {
     var stepManager = PomodoroStepManger()
 
     private lazy var currentStepLabel = UILabel().then {
-        $0.text = stepManager.label.setUpLabelInCurrentStep(currentStep: stepManager.router.currentStep)
+        $0.text = stepManager.label.setUpLabelInCurrentStep(
+            currentStep: stepManager.router.currentStep
+        )
         $0.font = .pomodoroFont.heading3()
         $0.textAlignment = .center
     }
@@ -110,9 +112,9 @@ final class MainViewController: UIViewController {
         stepManager.setRouterObservers()
         print(stepManager.router.currentStep)
         setUpPomodoroCurrentStepLabel()
-        
+
         let documentsDirectory = NSSearchPathForDirectoriesInDomains(
-            .documentDirectory, .userDomainMask, 
+            .documentDirectory, .userDomainMask,
             true
         )[0]
         print(documentsDirectory)
@@ -258,8 +260,7 @@ extension MainViewController {
                 self.longPressGestureRecognizer.isEnabled = false
             }
 
-            stepManager.timeSetting.setUptimeInCurrentStep()
-//            stepManager.timeSetting.setUpBreakTime()
+            stepManager.timeSetting.initPomodoroStep()
             currentStepLabel.text = ""
             UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
             setupTimeAndTag()
@@ -345,7 +346,8 @@ extension MainViewController {
             if minutes == 0, seconds == 0 {
                 timer.invalidate()
                 setupUIWhenTimerStart(isStopped: true)
-                RealmService.update(currentPomodoro!) { updatedPomodoro in
+                guard let currentPomodoro else { return }
+                RealmService.update(currentPomodoro) { updatedPomodoro in
                     updatedPomodoro.phase += 1
                     if updatedPomodoro.phase == 5 {
                         updatedPomodoro.isSuccess = true
@@ -380,6 +382,7 @@ extension MainViewController {
         currentStepLabel.text = stepManager.label.setUpLabelInCurrentStep(
             currentStep: stepManager.router.currentStep
         )
+
         if stepManager.router.currentStep != .start {
             timeSettingGuideButton.isHidden = true
         } else {

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -170,12 +170,10 @@ final class TimeSettingViewController: UIViewController {
     }
 
     private func didTapConfirmButton() {
-        print("selected : ", Int(centerIndexPath?.item ?? 0))
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
         RealmService.createPomodoro(tag: "DEFUALT")
         let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
         Log.info(data)
-        print(data)
         dismiss(animated: true)
     }
 

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -22,7 +22,6 @@ final class TimeSettingViewController: UIViewController {
     private var endTime: String?
     private var isSelectedCellBiggerfive: Bool = true
     private let stepManager = PomodoroStepManger()
-    private let dataBase = DatabaseManager.shared
 
     private weak var delegate: TimeSettingViewControllerDelegate?
 
@@ -173,10 +172,10 @@ final class TimeSettingViewController: UIViewController {
     private func didTapConfirmButton() {
         print("selected : ", Int(centerIndexPath?.item ?? 0))
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
-        let datas = dataBase.createPomodoro(tag: "DEFUALT")
-        let data = dataBase.read(Pomodoro.self).last
+        RealmService.createPomodoro(tag: "DEFUALT")
+        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
+        Log.info(data)
         print(data)
-        // router 시작..입니다..?
         dismiss(animated: true)
     }
 

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -22,6 +22,7 @@ final class TimeSettingViewController: UIViewController {
     private var endTime: String?
     private var isSelectedCellBiggerfive: Bool = true
     private let stepManager = PomodoroStepManger()
+    private let dataBase = DatabaseManager.shared
 
     private weak var delegate: TimeSettingViewControllerDelegate?
 
@@ -170,7 +171,11 @@ final class TimeSettingViewController: UIViewController {
     }
 
     private func didTapConfirmButton() {
+        print("selected : ", Int(centerIndexPath?.item ?? 0))
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
+        let datas = dataBase.createPomodoro(tag: "DEFUALT")
+        let data = dataBase.read(Pomodoro.self).last
+        print(data)
         // router 시작..입니다..?
         dismiss(animated: true)
     }

--- a/Sources/Model/PomodoroRouter.swift
+++ b/Sources/Model/PomodoroRouter.swift
@@ -83,8 +83,8 @@ final class PomodoroRouter {
             pomodoroMainViewController.stepManager.router = self
             navigationController.pushViewController(pomodoroMainPageViewController, animated: true)
         case .rest:
-            if maxStep < PomodoroRouter.pomodoroCount {
-                breakTimerViewController.stepManager.router = self
+            if maxStep < pomodoroCount {
+                pomodoroMainViewController.stepManager.router = self
                 navigationController.popToRootViewController(animated: true)
             } else {
                 breakTimerViewController.stepManager.router = self
@@ -105,9 +105,12 @@ final class PomodoroRouter {
         case var .rest(count):
             count = pomodoroCount
             if count < maxStep {
-                PomodoroRouter.pomodoroCount += 1
-                currentStep = .focus(count: PomodoroRouter.pomodoroCount)
+                pomodoroCount += 1
+                currentStep = .focus(count: pomodoroCount)
+            } else if count == maxStep {
+                currentStep = .end
             } else {
+                pomodoroCount = 0
                 currentStep = .end
                 currentStep = .start
             }
@@ -122,7 +125,7 @@ final class PomodoroRouter {
 
 final class PomodoroStepTimeChange {
     private let pomodoroTimeManager = PomodoroTimeManager.shared
-    private var pomodoroCurrentCount = PomodoroRouter.pomodoroCount
+    private var pomodoroCurrentCount = PomodoroRouter.shared.pomodoroCount
     private var currentStep: PomodoroTimerStep?
     private var shortBreakTime: Int?
     private var longBreakTime: Int?
@@ -187,6 +190,9 @@ extension PomodoroStepTimeChage: PomodoroStepObserver {
         pomodoroCurrentCount = counter
     }
 extension PomodoroStepTimeChange: PomodoroStepObserver {
+    func didPomodoroStepCounterChange(stepCounter counter: Int) {
+        pomodoroCurrentCount = counter
+    }
     func didPomodoroStepChange(to step: PomodoroTimerStep) {
         currentStep = step
     }

--- a/Sources/Model/PomodoroRouter.swift
+++ b/Sources/Model/PomodoroRouter.swift
@@ -168,7 +168,6 @@ final class PomodoroStepTimeChange {
     }
 }
 
-extension PomodoroStepTimeChage: PomodoroStepObserver {
 extension PomodoroStepTimeChange: PomodoroStepObserver {
     func didPomodoroStepChange(to step: PomodoroTimerStep) {
         currentStep = step


### PR DESCRIPTION
# 설명

- Realm 데이터베이스 적용을 통한 뽀모 도로 실패 기록하는 것이다. 이때 1회차 60초 전에 타이머를 초기화 하는 경우에는 실패 적용이 안되게끔한다.

실패했을 때 영상

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/122281984/b6713fae-8901-4964-91dd-42a2d1cbcfed

성공했을 때 
- (용량이 커서 zip으로 올립니다..)

[Simulator Screen Recording - iPhone 15 Pro - 2024-04-16 at 10.56.09.mp4.zip](https://github.com/HGU-iOS-Study-Group/Pomodoro/files/14986089/Simulator.Screen.Recording.-.iPhone.15.Pro.-.2024-04-16.at.10.56.09.mp4.zip)


1회차 60초이네 포기 상황!

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/122281984/7690c8fc-fe85-43ed-9deb-69872676b0fa



- close issues
#236 

# TODO
- [x] 첫 한 스텝 이후에도 실패 기록 정상적으로 기록하기
- [x] 첫 한 스텝 이후에도 렘에서의 스텝 적용이 되게끔 하기
