### PR TITLE
[Bug][설정] 데이터 초기화를 실행해도 대시보드 데이터가 남아있는 현상

### DIFF
--- a/Sources/DashBoardScene/ViewControllers/DashBoardTabViewController.swift
+++ b/Sources/DashBoardScene/ViewControllers/DashBoardTabViewController.swift
@@ -32,6 +32,10 @@ final class DashBoardTabViewController: UIViewController {
         segmentChanged()
     }
 
+    override func viewWillAppear(_: Bool) {
+        segmentChanged()
+    }
+
     private func caculateTotalParticipate() -> Int {
         if let data = try? RealmService.read(Pomodoro.self) {
             let filteredData = data.filter { $0.participateDate < Date() }


### PR DESCRIPTION
close #269 


https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/cf317e61-4f67-4dd6-850c-68f192454020

- [x] 데이터 초기화 이후 대시보드 화면에 들어오면 데이터가 모두 사라지도록 구현