### PR TITLE
[Fix] #277 [Bug][대시보드] 사용자가 설정한 시간 설정을 불러오지 못하고, phase 값을 불러오는 현상 1차 수정

### DIFF
--- a/Sources/BreakScene/BreakTimerViewController.swift
+++ b/Sources/BreakScene/BreakTimerViewController.swift
@@ -73,7 +73,8 @@ final class BreakTimerViewController: UIViewController, TimeSettingViewControlle
         startTimer()
 
         if let realmOption = try? RealmService.read(Option.self).first,
-           realmOption.isTimerEffect {
+           realmOption.isTimerEffect
+        {
             startAnimationTimer()
         }
 

--- a/Sources/Common/Managers/DatabaseManager.swift
+++ b/Sources/Common/Managers/DatabaseManager.swift
@@ -21,7 +21,7 @@ enum RealmService {
         }
     }
 
-    static func createPomodoro(tag: String) {
+    static func createPomodoro(tag: String, phaseTime: Int) {
         do {
             let database = try Realm()
             Log.info("Realm is located at: \(String(describing: database.configuration.fileURL))")
@@ -29,7 +29,13 @@ enum RealmService {
             if let lastPomodoro = database.objects(Pomodoro.self).last {
                 id = lastPomodoro.id + 1
             }
-            let pomodoro = Pomodoro(id: id, phase: 1, currentTag: tag, participateDate: Date.now)
+            let pomodoro = Pomodoro(
+                id: id,
+                phaseTime: phaseTime,
+                phase: 1,
+                currentTag: tag,
+                participateDate: Date.now
+            )
             write(pomodoro)
         } catch {
             Log.error(error)

--- a/Sources/Common/Managers/PomodoroTimeManager.swift
+++ b/Sources/Common/Managers/PomodoroTimeManager.swift
@@ -54,8 +54,8 @@ final class PomodoroTimeManager {
         pomodoroTimer?.invalidate()
         currentTime = 0
 
-        let option = try? RealmService.read(Option.self).first
-        maxTime = (option?.focusTime ?? 25) * 60
+        let recent = try? RealmService.read(Pomodoro.self).last
+        maxTime = (recent?.phaseTime ?? 25) * 60
 
         completion()
     }
@@ -86,8 +86,8 @@ final class PomodoroTimeManager {
             isRestored = true
             currentTime = updatedCurrTime
         } else {
-            let option = try? RealmService.read(Option.self).first
-            maxTime = (option?.focusTime ?? 25) * 60
+            let recent = try? RealmService.read(Pomodoro.self).last
+            maxTime = (recent?.phaseTime ?? 25) * 60
             currentTime = 0
         }
     }

--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -128,7 +128,6 @@ final class MainViewController: UIViewController {
                 Option(
                     shortBreakTime: 5,
                     longBreakTime: 20,
-                    focusTime: 25,
                     isVibrate: false,
                     isTimerEffect: true
                 )
@@ -150,7 +149,9 @@ final class MainViewController: UIViewController {
         setupActions()
         setupLongPressGestureRecognizer()
         setupTimeLabelTapGestureRecognizer()
-        setupTimeAndTag()
+
+        // TODO: 가장 최근 뽀모도로 시간이 나타나야함.
+        setupRecentPomodoroData()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -163,7 +164,12 @@ final class MainViewController: UIViewController {
         }
     }
 
-    private func setupTimeAndTag() {
+    private func setupRecentPomodoroData() {
+        let recent = try? RealmService.read(Pomodoro.self).last
+        if recent == nil {
+            needOnboarding = true
+        }
+
         if needOnboarding {
             tagButton.setTitle(nil, for: .normal)
             tagButton.setImage(UIImage(named: "onBoardingTag"), for: .normal)
@@ -174,26 +180,83 @@ final class MainViewController: UIViewController {
                 .strokeWidth: 1,
             ])
             pomodoroTimeManager.setupMaxTime(time: 25 * 60)
-            needOnboarding = false
         } else {
-            tagButton.setTitle("Tag", for: .normal)
+            Log.debug(recent)
+            tagButton.setTitle(recent?.currentTag, for: .normal)
             tagButton.setImage(nil, for: .normal)
             timeLabel.attributedText = nil
 
-            let option = try? RealmService.read(Option.self).first
             // 배포용
-//            pomodoroTimeManager.setupMaxTime(time: (option?.focusTime ?? 25) * 60)
+//            pomodoroTimeManager.setupMaxTime(
+//                time: (recent?.phaseTime ?? 25) * 60
+//            )
             // 디버깅용
-            // pomodoroTimeManager.setupMaxTime(time: (option?.focusTime ?? 25))
-            Log.info("Max time : \(pomodoroTimeManager.maxTime)")
-            Log.info("Current time : \(pomodoroTimeManager.currentTime)")
+            pomodoroTimeManager.setupMaxTime(
+                time: (recent?.phaseTime ?? 25)
+            )
+
             timeLabel.text = String(
                 format: "%02d:%02d",
-                (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) / 60,
-                (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) % 60
+                (pomodoroTimeManager.maxTime -
+                    pomodoroTimeManager.currentTime) / 60,
+                (pomodoroTimeManager.maxTime -
+                    pomodoroTimeManager.currentTime) % 60
             )
         }
     }
+
+    private func setupTimeUI() {
+        let recent = try? RealmService.read(Pomodoro.self).last
+
+        if recent == nil {
+            tagButton.setTitle(nil, for: .normal)
+            tagButton.setImage(UIImage(named: "onBoardingTag"), for: .normal)
+        } else {
+            tagButton.setTitle(recent?.currentTag, for: .normal)
+            tagButton.setImage(nil, for: .normal)
+        }
+
+        timeLabel.attributedText = nil
+        timeLabel.text = String(
+            format: "%02d:%02d",
+            (pomodoroTimeManager.maxTime -
+                pomodoroTimeManager.currentTime) / 60,
+            (pomodoroTimeManager.maxTime -
+                pomodoroTimeManager.currentTime) % 60
+        )
+    }
+
+//    private func setupTimeAndTag(with currentPomodoro: Pomodoro) {
+//        if needOnboarding {
+//            tagButton.setTitle(nil, for: .normal)
+//            tagButton.setImage(UIImage(named: "onBoardingTag"), for: .normal)
+//            timeLabel.attributedText = .init(string: "25:00", attributes: [
+//                .font: UIFont.pomodoroFont.heading1(),
+//                .foregroundColor: UIColor.clear,
+//                .strokeColor: UIColor.pomodoro.blackHigh,
+//                .strokeWidth: 1,
+//            ])
+//            pomodoroTimeManager.setupMaxTime(time: 25 * 60)
+//            needOnboarding = false
+//        } else {
+//            tagButton.setTitle(currentPomodoro.currentTag, for: .normal)
+//            tagButton.setImage(nil, for: .normal)
+//            timeLabel.attributedText = nil
+//
+//            // FIXME: 삭제될 부분입니다..
+    ////            let option = try? RealmService.read(Option.self).first
+//            // 배포용
+    ////            pomodoroTimeManager.setupMaxTime(time: (option?.focusTime ?? 25) * 60)
+//            // 디버깅용
+//            // pomodoroTimeManager.setupMaxTime(time: (option?.focusTime ?? 25))
+//
+//            timeLabel.text = String(
+//                format: "%02d:%02d",
+//                (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) / 60,
+//                (pomodoroTimeManager.maxTime - pomodoroTimeManager.currentTime) % 60
+//            )
+//        }
+//    }
 
     private func setupActions() {
         tagButton.addTarget(
@@ -243,11 +306,18 @@ extension MainViewController {
         longPressTimer?.fire()
 
         if gestureRecognizer.state == .cancelled || gestureRecognizer.state == .ended {
+            Log.debug("뽀모도로 진행 취소!!")
+
             stopTimeProgressBar.isHidden = true
             longPressGuideLabel.isHidden = false
             longPressTime = 0.0
             stopTimeProgressBar.progress = 0.0
             longPressTimer?.invalidate()
+
+            guard let current = try? RealmService.read(Pomodoro.self).last else { return }
+            RealmService.update(current) { pomodoro in
+                pomodoro.phase = -1
+            }
         }
     }
 
@@ -269,7 +339,9 @@ extension MainViewController {
             stepManager.timeSetting.initPomodoroStep()
             currentStepLabel.text = ""
             UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
-            setupTimeAndTag()
+
+//            setupTimeAndTag()
+            setupRecentPomodoroData()
 
             stopTimeProgressBar.isHidden = true
             longPressGuideLabel.isHidden = true
@@ -282,6 +354,7 @@ extension MainViewController {
         Log.info("set pomodorotime")
 
         let timeSettingViewController = TimeSettingViewController(isSelectedTime: false, delegate: self)
+
         if let sheet = timeSettingViewController.sheetPresentationController {
             sheet.detents = [
                 .custom { context in
@@ -329,6 +402,7 @@ extension MainViewController {
         guard pomodoroTimeManager.maxTime != 0 else {
             return
         }
+        needOnboarding = false
         if timeLabel.attributedText != nil {
             timeLabel.attributedText = nil
         }
@@ -342,9 +416,10 @@ extension MainViewController {
         // 강제종료 이후 정보 불러온 상황이 아닐때 (클릭 상황)
         if pomodoroTimeManager.isRestored == false {
             let prevPomodoro = try? RealmService.read(Pomodoro.self).last
+
             // 이전 뽀모도로 끝난 경우
-            if prevPomodoro?.phase == 0 || prevPomodoro == nil {
-                RealmService.createPomodoro(tag: "임시")
+            if prevPomodoro?.phase == -1 || prevPomodoro?.isSuccess == true || prevPomodoro == nil {
+                RealmService.createPomodoro(tag: "임시", phaseTime: pomodoroTimeManager.maxTime)
             }
             currentPomodoro = try? RealmService.read(Pomodoro.self).last
         }
@@ -361,6 +436,7 @@ extension MainViewController {
 
                 RealmService.update(currentPomodoro!) { updatedPomodoro in
                     updatedPomodoro.phase += 1
+
                     if updatedPomodoro.phase == 5 {
                         updatedPomodoro.isSuccess = true
                         updatedPomodoro.phase = 0
@@ -466,11 +542,14 @@ extension MainViewController {
 extension MainViewController: TimeSettingViewControllerDelegate {
     func didSelectTime(time: Int) {
         pomodoroTimeManager.setupMaxTime(time: time)
-        guard let option = try? RealmService.read(Option.self).first else { return }
-        RealmService.update(option) { opt in
-            opt.focusTime = time
-        }
-        setupTimeAndTag()
+
+        setupTimeUI()
+
+        // FIXME: 삭제될 녀석들입니다..
+//        guard let option = try? RealmService.read(Option.self).first else { return }
+//        RealmService.update(option) { opt in
+//            opt.focusTime = time
+//        }
     }
 }
 

--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -29,9 +29,13 @@ final class TimeSettingViewController: UIViewController {
         isSelectedTime: Bool,
         delegate: TimeSettingViewControllerDelegate
     ) {
+        super.init(nibName: nil, bundle: nil)
+
+        let recent = try? RealmService.read(Pomodoro.self).last
+        selectedTime = recent?.phaseTime ?? 25
+
         self.isSelectedTime = isSelectedTime
         self.delegate = delegate
-        super.init(nibName: nil, bundle: nil)
     }
 
     @available(*, unavailable)
@@ -176,14 +180,14 @@ final class TimeSettingViewController: UIViewController {
     private func didTapConfirmButton() {
         Log.debug("Selected Time: \(Int(centerIndexPath?.item ?? 0))")
         delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
-        RealmService.createPomodoro(tag: "DEFUALT")
+//        RealmService.createPomodoro(tag: "DEFUALT")
 //        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
         dismiss(animated: true)
     }
 
     @objc private func didTapCloseButton() {
-        Log.debug("Selected Time: \(Int(centerIndexPath?.item ?? 0))")
-        delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
+//        Log.debug("Selected Time: \(Int(centerIndexPath?.item ?? 0))")
+//        delegate?.didSelectTime(time: Int(centerIndexPath?.item ?? 0))
         dismiss(animated: true)
     }
 }

--- a/Sources/Model/Option.swift
+++ b/Sources/Model/Option.swift
@@ -13,21 +13,18 @@ class Option: Object {
     @Persisted(primaryKey: true) var id = UUID().uuidString
     @Persisted var shortBreakTime: Int
     @Persisted var longBreakTime: Int
-    @Persisted var focusTime: Int
     @Persisted var isVibrate: Bool
     @Persisted var isTimerEffect: Bool
 
     convenience init(
         shortBreakTime: Int = 5,
         longBreakTime: Int = 20,
-        focusTime: Int = 25,
         isVibrate: Bool = false,
         isTimerEffect: Bool = true
     ) {
         self.init()
         self.shortBreakTime = shortBreakTime
         self.longBreakTime = longBreakTime
-        self.focusTime = focusTime
         self.isVibrate = isVibrate
         self.isTimerEffect = isTimerEffect
     }

--- a/Sources/Model/Pomodoro.swift
+++ b/Sources/Model/Pomodoro.swift
@@ -11,13 +11,16 @@ import UIKit
 
 class Pomodoro: Object {
     @Persisted(primaryKey: true) var id: Int
-    @Persisted var phase: Int // 1 -> 2 -> 3 -> 4 순으로 가되, 뽀모도로가 모두 완료되면 (성공이든, 실패이든 0으로 변경)
+    @Persisted var phaseTime: Int
+    @Persisted var phase: Int
+    // 1 -> 2 -> 3 -> 4 순으로 가되, 뽀모도로가 모두 완료되면 (성공이든, 실패이든 0으로 변경)
     @Persisted var currentTag: String
     @Persisted var participateDate: Date
     @Persisted var isSuccess: Bool
 
     convenience init(
         id: Int,
+        phaseTime: Int,
         phase: Int = 1,
         currentTag: String = "DEFAULT",
         participateDate: Date = Date.now,
@@ -25,6 +28,7 @@ class Pomodoro: Object {
     ) {
         self.init()
         self.id = id
+        self.phaseTime = phaseTime
         self.phase = phase
         self.currentTag = currentTag
         self.participateDate = participateDate


### PR DESCRIPTION
<img width="800" alt="2024-06-06_03-43-51" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/61077215/e39fa172-d007-4e8b-8163-b8c88551b836">

<img width="800" alt="2024-06-06_03-44-25" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/61077215/f72f285f-b0eb-489b-903e-38289da26ef4">

이제 뽀모도로 모델에 phaseTime이라는 값이 들어가게 됌. 설정한 값대로 값이 들어가고 startTimer를 했을 때 뽀모도로 객체가 하나 생성됨. phase는 순서대로 회차 대로 따라가다가 전체 phase (4회차까지) 종료되면 phase는 0으로 변경되고, IsSuccess를 true로 설정함. 추가적으로, phase를 따라가다가 중간에 (예를 들어 2회차 도중에) 뽀모도로를 롱프레스해서 중간에 종료할 경우에 진행하던 phase 값을 -1로 변경해서 실패한 뽀모도로임을 확인할 수 있다. 
(이 모든 과정은 한 사이클 진행 도중에 phaseTime을 변경할 수 없다는 것을 전제로 한다)

대시보드 관련 코드는 잘몰라서 일단 이렇게 까지만 해놨는데 그 이후 대시보드는 phaseTime을 잘 가져와서 사용하면 정상적으로 적용할 수 있지 않을까 생각한다.