### PR TITLE
[Fix] Tag 렘에 이전 뽀모도로에 저장되는 현상 수정

### DIFF
--- a/Sources/MainScene/ViewControllers/MainViewController.swift
+++ b/Sources/MainScene/ViewControllers/MainViewController.swift
@@ -17,6 +17,7 @@ final class MainViewController: UIViewController {
     private var longPressTimer: Timer?
     private var longPressTime: Float = 0.0
     private var currentPomodoro: Pomodoro?
+    private var currentTagName: String = ""
     private var needOnboarding = false
     private let longPressGestureRecognizer = UILongPressGestureRecognizer()
 
@@ -419,7 +420,7 @@ extension MainViewController {
 
             // 이전 뽀모도로 끝난 경우
             if prevPomodoro?.phase == -1 || prevPomodoro?.isSuccess == true || prevPomodoro == nil {
-                RealmService.createPomodoro(tag: "임시", phaseTime: pomodoroTimeManager.maxTime)
+                RealmService.createPomodoro(tag: currentTagName, phaseTime: pomodoroTimeManager.maxTime)
             }
             currentPomodoro = try? RealmService.read(Pomodoro.self).last
         }
@@ -558,18 +559,20 @@ extension MainViewController: TagModalViewControllerDelegate {
         let backgroundColor = TagCase(rawValue: tagColor)?.backgroundColor ?? .gray
         let titleColor = TagCase(rawValue: tagColor)?.typoColor ?? .gray
 
-        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
-        RealmService.update(data) { data in
-            data.currentTag = tagName
-        }
+//        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
+//        RealmService.update(data) { data in
+//            data.currentTag = tagName
+//        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.tagButton.setImage(nil, for: .normal)
-            self.tagButton.setTitle(data.currentTag, for: .normal)
+            self.tagButton.setTitle(tagName, for: .normal)
             self.tagButton.backgroundColor = titleColor
             self.tagButton.setTitleColor(.white, for: .normal)
         }
+
+        currentTagName = tagName
         Log.info("Selected Tag: \(tagName), Color: \(tagColor)")
     }
 

--- a/Sources/MainScene/ViewControllers/TagModalViewController.swift
+++ b/Sources/MainScene/ViewControllers/TagModalViewController.swift
@@ -265,10 +265,10 @@ final class TagModalViewController: UIViewController {
     // TODO: 태그 값이 메인뷰에 전달하는 함수
     func selectTag(tagName: String, tagColor: String) {
         selectionDelegate?.tagSelected(tagName: tagName, tagColor: tagColor)
-        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
-        RealmService.update(data) { data in
-            data.currentTag = tagName
-        }
+//        let data = (try? RealmService.read(Pomodoro.self).last) ?? Pomodoro()
+//        RealmService.update(data) { data in
+//            data.currentTag = tagName
+//        }
         dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
<img width="800" alt="2024-06-06_21-11-12" src="https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/61077215/abd4bc70-d84d-483e-972f-d40605aa7d11">

이전 시작하기 전의 뽀모도로 렘데이터의 태그 값이 변경되던 이슈 해결
-> 뽀모도로 생성시 생겨나는 렘데이터의 태그값이 변경되도록 수정함