### PR TITLE
[Bug][대시보드] 사용자가 설정한 시간 설정을 불러오지 못하고, phase 값을 불러오는 현상

### DIFF
--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -75,7 +75,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         ) else { return [:] }
 
         let sessions = (try? RealmService.read(Pomodoro.self).filter {
-            $0.participateDate >= startOfDay && $0.participateDate < endOfDay
+            $0.participateDate >= startOfDay && $0.participateDate < endOfDay && $0.isSuccess == true
         }) ?? []
 
         var focusTimePerTag = [String: Int]()
@@ -112,10 +112,10 @@ final class DashboardPieChartCell: UICollectionViewCell {
     private func calculateFocusTimePerTag(from startDate: Date, to endDate: Date) -> [String: Int] {
         var focusTimePerTag = [String: Int]()
         let filteredSessions = (try? RealmService.read(Pomodoro.self).filter {
-            $0.participateDate >= startDate && $0.participateDate < endDate
+            $0.participateDate >= startDate && $0.participateDate < endDate && $0.isSuccess == true
         }) ?? []
         for session in filteredSessions {
-            focusTimePerTag[session.currentTag, default: 0] += session.phase
+            focusTimePerTag[session.currentTag, default: 0] += session.phaseTime
         }
         return focusTimePerTag
     }

--- a/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
+++ b/Sources/DashBoardScene/Views/DashboardPieChartCell.swift
@@ -205,7 +205,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         var timeText = ""
         if days > 0 { timeText += "\(days)일 " }
         if hours > 0 || days > 0 { timeText += "\(hours)시간 " }
-        timeText += "\(minutes)분"
+        timeText += "\(minutes * 4)분"
         return timeText
     }
 
@@ -263,7 +263,7 @@ final class DashboardPieChartCell: UICollectionViewCell {
         if hours > 0 || days > 0 {
             totalTimeText += "\(hours)시간"
         }
-        totalTimeText += "\(minutes)분"
+        totalTimeText += "\(minutes * 4)분"
 
         chartCenterText.text = totalTimeText
         chartCenterText.then {


### PR DESCRIPTION
close #277 
phasetime으로 대시보드 수정 + 성공시에만 대시보드에 저장되도록 수정 완료

- [x] phasetime에서 시간을 대시보드에 가져오도록 수정 완료
- [x] phasetime * 4 한 결과를 가져오도록 수정 완료
- [x] 한 회차의 뽀모도로가 끝났을 때. 즉, isSuccess가 참인 경우 (성공한 경우)에만 대시보드에 값을 가져오도록 수정 완료


https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/743ad0bf-0c65-4a12-be8c-1e2ebeb9f33d

https://github.com/HGU-iOS-Study-Group/Pomodoro/assets/97924765/7efeaf6f-7b61-43c9-bc74-dd014c4744f0



