### PR TITLE
[FIx] 휴식시간 포함한 TimeSettingViewController에 종료시간 표시

### DIFF
--- a/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
+++ b/Sources/MainScene/ViewControllers/TimeSettingViewController.swift
@@ -14,6 +14,7 @@ protocol TimeSettingViewControllerDelegate: AnyObject {
 }
 
 final class TimeSettingViewController: UIViewController {
+
     private var isSelectedTime: Bool = false
     private let colletionViewIdentifier = "TimerCollectionViewCell"
     private var centerIndexPath: IndexPath?
@@ -22,7 +23,8 @@ final class TimeSettingViewController: UIViewController {
     private let pomodoroTimeManager = PomodoroTimeManager.shared
     private var endTime: String?
     private var isSelectedCellBiggerfive: Bool = true
-    private let stepManager = PomodoroStepManger()
+    var stepManager = PomodoroStepManger()
+    private lazy var breakTime = stepManager.timeSetting.setUpBreakTime()
 
     private weak var delegate: TimeSettingViewControllerDelegate?
 
@@ -172,7 +174,7 @@ final class TimeSettingViewController: UIViewController {
         let currentTime = Date()
 
         guard let endTime = Calendar.current.date(
-            byAdding: .second, value: selectedTime, to: currentTime
+            byAdding: .second, value: (selectedTime + breakTime) * 4, to: currentTime
         ) else {
             return
         }


### PR DESCRIPTION
#설명
휴식시간 포함한 시간 설정 결과 및 종료시간을 시간 설정 페이지에 보여줘야 한다.

close #321 

https://github.com/user-attachments/assets/64283670-70ab-4bdc-9214-fd0c61e11a1d

